### PR TITLE
[DX12][Vulkan] Maintenance

### DIFF
--- a/examples/AppBase/3rd-party/CMakeLists.txt
+++ b/examples/AppBase/3rd-party/CMakeLists.txt
@@ -1,6 +1,7 @@
 # Using fetch content for 3rd-party libraries 
 # to avoid adding these dependencies into main repo
 include(FetchContent)
+include(${PROJECT_SOURCE_DIR}/cmake/FetchWinPix.cmake)
 
 macro(fetch_git_repo URL TAG TARGET_NAME)
     FetchContent_Declare(

--- a/examples/AppBase/AppRunner.cpp
+++ b/examples/AppBase/AppRunner.cpp
@@ -221,11 +221,15 @@ int AppRunner::Run(IApp* pUserApp) {
 
             auto& pass = commandList->BeginRenderPass(passAction);
 
+            commandList->PushDebugGroup("Draw scene", {0.5, 0.9, 0.4, 1.0});
 
             pUserApp->OnRenderFrame(pass);
 
-            ImGui_ImplAlloy_RenderDrawData(draw_data, pass);
+            commandList->PopDebugGroup();
 
+            commandList->PushDebugGroup("Draw ImGui", {0.3, 0.4, 0.8, 1.0});
+            ImGui_ImplAlloy_RenderDrawData(draw_data, pass);
+            commandList->PopDebugGroup();
 
             commandList->EndPass();
             commandList->End();
@@ -253,7 +257,7 @@ void AppRunner::SetupAlloyEnv() {
     alloy::IContext::Options ctxOpt{};
     ctxOpt.debug = true;
 
-    auto ctx = alloy::IContext::Create(alloy::Backend::DX12, ctxOpt);
+    auto ctx = alloy::IContext::Create(alloy::Backend::Vulkan, ctxOpt);
     auto adp = ctx->EnumerateAdapters().front();
     
     alloy::IGraphicsDevice::Options devOpt{};

--- a/examples/AppBase/CMakeLists.txt
+++ b/examples/AppBase/CMakeLists.txt
@@ -21,5 +21,5 @@ target_link_libraries(AppBase
         imgui
         Veldrid
     PRIVATE
-        WinPixEventRuntime        
+        WinPixHeaders
 )

--- a/examples/AppBase/Utility/GPUCapture.cpp
+++ b/examples/AppBase/Utility/GPUCapture.cpp
@@ -13,22 +13,46 @@
 
 using namespace alloy;
 
-#ifdef USE_PIX
 
-void SetupCaptureEvent(common::sp<IGraphicsDevice> gd) {}
+#ifdef USE_PIX
+using PFN_PIXBeginCapture2
+    = HRESULT (WINAPI *) (DWORD , _In_opt_ const PPIXCaptureParameters );
+using PFN_PIXEndCapture
+    = HRESULT (WINAPI *) (BOOL);
+
+static PFN_PIXBeginCapture2 pfnPIXBeginCapture2 = nullptr;
+static PFN_PIXEndCapture pfnPIXEndCapture = nullptr;
+
+void SetupCaptureEvent(common::sp<IGraphicsDevice> gd) {
+    auto hPixRuntimeDll = LoadLibraryA("WinPixEventRuntime.dll");
+    if(hPixRuntimeDll) {
+        pfnPIXBeginCapture2 
+            = (PFN_PIXBeginCapture2)GetProcAddress(hPixRuntimeDll, "PIXBeginCapture2");
+        pfnPIXEndCapture 
+            = (PFN_PIXEndCapture)GetProcAddress(hPixRuntimeDll, "PIXEndCapture");
+
+        if (pfnPIXBeginCapture2 && pfnPIXEndCapture) {
+            std::cout << "PIX debug enabled.\n";
+        }  
+    }
+
+}
 
 void StartCapture() {
-    PIXCaptureParameters params {};
-    params.GpuCaptureParameters.FileName = L"Capture";
-    PIXBeginCapture(PIX_CAPTURE_GPU, &params);
+    if(pfnPIXBeginCapture2) {
+        PIXCaptureParameters params {};
+        params.GpuCaptureParameters.FileName = L"Capture";
+        pfnPIXBeginCapture2(PIX_CAPTURE_GPU, &params);
+    }
 }
 
 void StopCapture() {
-    PIXEndCapture(false);
+    if(pfnPIXEndCapture)
+        pfnPIXEndCapture(false);
 }
-#else
+#elif defined(USE_RENDERDOC)
 
-RENDERDOC_API_1_1_2* rdoc_api = nullptr;
+static RENDERDOC_API_1_1_2* rdoc_api = nullptr;
 void SetupCaptureEvent(common::sp<IGraphicsDevice> gd) {
 
     if (rdoc_api != nullptr){ return; }
@@ -84,6 +108,12 @@ void StartCapture() {
 void StopCapture() {
     if (rdoc_api) rdoc_api->EndFrameCapture(NULL, NULL);
 }
+
+#else
+
+void SetupCaptureEvent(alloy::common::sp<alloy::IGraphicsDevice> gd) { }
+void StartCapture() { }
+void StopCapture() { }
 
 #endif
 

--- a/examples/AppBase/Utility/GPUCapture.hpp
+++ b/examples/AppBase/Utility/GPUCapture.hpp
@@ -2,7 +2,7 @@
 
 #include <alloy/alloy.hpp>
 
-//#define USE_PIX
+//define USE_PIX
 
 void SetupCaptureEvent(alloy::common::sp<alloy::IGraphicsDevice> gd);
 void StartCapture();

--- a/examples/AppBase/Utility/ImGuiAlloyBackend.cpp
+++ b/examples/AppBase/Utility/ImGuiAlloyBackend.cpp
@@ -697,6 +697,7 @@ void ImGuiAlloyBackend::_UpdateTexture(ImTextureData* tex) {
             desc.format = alloy::PixelFormat::R8_G8_B8_A8_UNorm;
 
             fontTex = gd->GetResourceFactory().CreateTexture(desc);
+            fontTex->SetDebugName("ImGUI text atlas");
         }
 
         //Create sampler

--- a/examples/PBRRenderer/CMakeLists.txt
+++ b/examples/PBRRenderer/CMakeLists.txt
@@ -18,4 +18,5 @@ target_compile_features(PBRRenderer PRIVATE cxx_std_20)
 
 if(WIN32)
     alloy_copy_dxc_runtime_libs(PBRRenderer)
+    pix_runtime_copy_binaries(PBRRenderer)
 endif()

--- a/examples/PBRRenderer/MeshBuilder.cpp
+++ b/examples/PBRRenderer/MeshBuilder.cpp
@@ -38,12 +38,12 @@ Mesh BuildBoxMesh(float length, float width, float height) {
         );
         constexpr auto vertCnt = 6;
         const Vertex verts[vertCnt] = {
-            {vertPos[v0], uv[v0], normal, tangent, bitangent},
-            {vertPos[v2], uv[v2], normal, tangent, bitangent},
-            {vertPos[v1], uv[v1], normal, tangent, bitangent},
-            {vertPos[v1], uv[v1], normal, tangent, bitangent},
-            {vertPos[v2], uv[v2], normal, tangent, bitangent},
-            {vertPos[v3], uv[v3], normal, tangent, bitangent}
+            {vertPos[v0], uv[0], normal, tangent, bitangent},
+            {vertPos[v2], uv[2], normal, tangent, bitangent},
+            {vertPos[v1], uv[1], normal, tangent, bitangent},
+            {vertPos[v1], uv[1], normal, tangent, bitangent},
+            {vertPos[v2], uv[2], normal, tangent, bitangent},
+            {vertPos[v3], uv[3], normal, tangent, bitangent}
         };
 
         vertices.insert(vertices.end(), verts, verts+vertCnt);

--- a/examples/PBRRenderer/MeshRenderer.cpp
+++ b/examples/PBRRenderer/MeshRenderer.cpp
@@ -95,7 +95,7 @@ void MeshRenderer::_CreateObjRenderPipeline() {
     pipelineDescription.primitiveTopology = alloy::PrimitiveTopology::TriangleList;
 
     using VL = alloy::VertexLayout;
-    pipelineDescription.shaderSet.vertexLayouts = { {} };
+    pipelineDescription.shaderSet.vertexLayouts = { };
 
     //struct Vertex {
     //    float3 position : POSITION;

--- a/examples/SimpleQuad/CMakeLists.txt
+++ b/examples/SimpleQuad/CMakeLists.txt
@@ -10,4 +10,5 @@ target_compile_features(SimpleQuad PRIVATE cxx_std_20)
 
 if(WIN32)
     alloy_copy_dxc_runtime_libs(SimpleQuad)
+    pix_runtime_copy_binaries(SimpleQuad)
 endif()

--- a/examples/cmake/FetchWinPix.cmake
+++ b/examples/cmake/FetchWinPix.cmake
@@ -48,15 +48,20 @@ endif()
 set(PIX_RUNTIME_ROOT_DIR "${PIX_RUNTIME_SRC}")
 set(PIX_RUNTIME_BIN_DIR "${PIX_RUNTIME_ROOT_DIR}/bin/${PIX_RUNTIME_ARCH}")
 
+# Add include directories
+set(PIX_RUNTIME_INCLUDE_DIR "${PIX_RUNTIME_ROOT_DIR}/Include")
+
+add_library(WinPixHeaders INTERFACE)
+target_include_directories(WinPixHeaders INTERFACE "${PIX_RUNTIME_INCLUDE_DIR}")
+
 add_library(WinPixEventRuntime SHARED IMPORTED GLOBAL)
 set_target_properties(WinPixEventRuntime 
     PROPERTIES 
         IMPORTED_LOCATION ${PIX_RUNTIME_BIN_DIR}
         IMPORTED_IMPLIB ${PIX_RUNTIME_BIN_DIR}/WinPixEventRuntime.lib)
 
-# Add include directories
-set(PIX_RUNTIME_INCLUDE_DIR "${PIX_RUNTIME_ROOT_DIR}/Include")
-target_include_directories(WinPixEventRuntime INTERFACE "${PIX_RUNTIME_INCLUDE_DIR}")
+#target_include_directories(WinPixEventRuntime INTERFACE "${PIX_RUNTIME_INCLUDE_DIR}")
+target_link_libraries(WinPixEventRuntime INTERFACE WinPixHeaders)
 
 # Set paths to the DLLs
 #set(AGILITY_Core_DLL "${PIX_RUNTIME_ROOT_DIR}/bin/${PIX_RUNTIME_ARCH}/D3D12Core.dll" PARENT_SCOPE)

--- a/include/alloy/Context.hpp
+++ b/include/alloy/Context.hpp
@@ -144,13 +144,16 @@ namespace alloy {
             float                 pointSizeGranularity;
             float                 lineWidthGranularity;
             SampleCount           maxMSAASampleCount;
+            uint32_t              minStructuredBufferStride;
         } limits;
 
         struct Capabilities {
             uint32_t supportMeshShader : 1;
+            uint32_t supportRayTracing : 1;
             uint32_t supportBindless : 1;
             uint32_t supportDedicatedTransferQueue : 1;
             uint32_t isUMA : 1;
+            uint32_t supportResizableBar : 1;
         } capabilities;
 
         std::vector<MemorySegmentProperties> memSegments;

--- a/src/backend/dx12/3rd-party/CMakeLists.txt
+++ b/src/backend/dx12/3rd-party/CMakeLists.txt
@@ -5,7 +5,6 @@
 project(dxc_third_party LANGUAGES C CXX)
 
 include(FetchAgilitySDK.cmake)
-include(FetchWinPix.cmake)
 
 # dx headers
 #add_subdirectory(DirectX-Headers)

--- a/src/backend/dx12/CMakeLists.txt
+++ b/src/backend/dx12/CMakeLists.txt
@@ -56,6 +56,8 @@ set(VLD_BACKEND_DXC_SRCS
     "${CMAKE_CURRENT_LIST_DIR}/D3DDescriptorHeapMgr.hpp"
     #"${CMAKE_CURRENT_LIST_DIR}/VkSurfaceUtil.cpp"
     #"${CMAKE_CURRENT_LIST_DIR}/VkSurfaceUtil.hpp"
+    "${CMAKE_CURRENT_LIST_DIR}/D3DPixEventEncoder.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/D3DPixEventEncoder.hpp"
 )
 
 source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${VLD_BACKEND_DXC_SRCS})
@@ -69,9 +71,9 @@ target_link_libraries(Veldrid
         D3D12MemoryAllocator
         AgilitySDK
     #    DirectX-Headers
-        d3d12.lib
-        dxgi.lib
-        WinPixEventRuntime
+    #    d3d12.lib
+    #    dxgi.lib
+    #    WinPixEventRuntime
     #    dxguid.lib
     #    common
     #    glm
@@ -105,6 +107,5 @@ function(alloy_copy_dxc_runtime_libs TARGET)
     message("alloy: will copy directx 12 runtime libraries to ${TARGET} binary path...")
 
     agility_sdk_copy_binaries(${TARGET})
-    pix_runtime_copy_binaries(${TARGET})
 
 endfunction()

--- a/src/backend/dx12/D3DPixEventEncoder.cpp
+++ b/src/backend/dx12/D3DPixEventEncoder.cpp
@@ -1,0 +1,238 @@
+#include "D3DPixEventEncoder.hpp"
+
+#include <cstdint>
+#include <vector>
+
+namespace alloy::dxc {
+
+
+#pragma region PixEventsCommon
+//Borrowed from PIXEventsCommon.h
+
+    #define PIX_EVENT_METADATA_NONE                     0x0
+    #define PIX_EVENT_METADATA_ON_CONTEXT               0x1
+    #define PIX_EVENT_METADATA_STRING_IS_ANSI           0x2
+    #define PIX_EVENT_METADATA_HAS_COLOR                0xF0
+
+    enum PIXEventType : std::uint8_t
+    {
+        PIXEvent_EndEvent       = 0x00,
+        PIXEvent_BeginEvent     = 0x01,
+        PIXEvent_SetMarker      = 0x02,
+    };
+    
+    //Bits 7-19 (13 bits)
+    static constexpr std::uint64_t PIXEventsBlockEndMarker     = 0x00000000000FFF80;
+
+    // V2 events
+
+    // Bits 00..06 (7 bits) - Size in QWORDS
+    static constexpr std::uint64_t PIXEventsSizeWriteMask      = 0x000000000000007F;
+    static constexpr std::uint64_t PIXEventsSizeBitShift       = 0;
+    static constexpr std::uint64_t PIXEventsSizeReadMask       = PIXEventsSizeWriteMask << PIXEventsSizeBitShift;
+    static constexpr std::uint64_t PIXEventsSizeMax            = (1ull << 7) - 1ull;
+
+    // Bits 07..11 (5 bits) - Event Type
+    static constexpr std::uint64_t PIXEventsTypeWriteMask      = 0x000000000000001F;
+    static constexpr std::uint64_t PIXEventsTypeBitShift       = 7;
+    static constexpr std::uint64_t PIXEventsTypeReadMask       = PIXEventsTypeWriteMask << PIXEventsTypeBitShift;
+
+    // Bits 12..19 (8 bits) - Event Specific Metadata
+    static constexpr std::uint64_t PIXEventsMetadataWriteMask  = 0x00000000000000FF;
+    static constexpr std::uint64_t PIXEventsMetadataBitShift   = 12;
+    static constexpr std::uint64_t PIXEventsMetadataReadMask   = PIXEventsMetadataWriteMask << PIXEventsMetadataBitShift;
+
+    // Buts 20..63 (44 bits) - Timestamp
+    static constexpr std::uint64_t PIXEventsTimestampWriteMask = 0x00000FFFFFFFFFFF;
+    static constexpr std::uint64_t PIXEventsTimestampBitShift  = 20;
+    static constexpr std::uint64_t PIXEventsTimestampReadMask  = PIXEventsTimestampWriteMask << PIXEventsTimestampBitShift;
+
+    inline std::uint64_t PIXEncodeEventInfo(std::uint64_t timestamp, PIXEventType eventType, std::uint8_t eventSize, std::uint8_t eventMetadata)
+    {
+        return
+            ((timestamp & PIXEventsTimestampWriteMask) << PIXEventsTimestampBitShift) |
+            (((std::uint64_t)eventType & PIXEventsTypeWriteMask) << PIXEventsTypeBitShift) |
+            (((std::uint64_t)eventMetadata & PIXEventsMetadataWriteMask) << PIXEventsMetadataBitShift) |
+            (((std::uint64_t)eventSize & PIXEventsSizeWriteMask) << PIXEventsSizeBitShift);
+    }
+
+#pragma endregion
+
+#pragma region Pix3Win
+//Borrowed from pix3_win.h
+
+
+// The following WINPIX_EVENT_* defines denote the different metadata values that have
+// been used by tools to denote how to parse pix marker event data. The first two values
+// are legacy values used by pix.h in the Windows SDK.
+#define WINPIX_EVENT_UNICODE_VERSION 0
+#define WINPIX_EVENT_ANSI_VERSION 1
+
+// These values denote PIX marker event data that was created by the WinPixEventRuntime.
+// In early 2023 we revised the PIX marker format and defined a new version number.
+#define WINPIX_EVENT_PIX3BLOB_VERSION 2
+#define WINPIX_EVENT_PIX3BLOB_V2 6345127 // A number that other applications are unlikely to have used before
+
+// For backcompat reasons, the WinPixEventRuntime uses the older PIX3BLOB format when it passes data
+// into the D3D12 runtime. It will be updated to use the V2 format in the future.
+#define D3D12_EVENT_METADATA WINPIX_EVENT_PIX3BLOB_VERSION
+
+
+inline void PIXInsertGPUMarkerOnContextForBeginEvent(_In_ ID3D12GraphicsCommandList* commandList, UINT8 eventType, _In_reads_bytes_(size) void* data, UINT size)
+{
+    UNREFERENCED_PARAMETER(eventType);
+    commandList->BeginEvent(WINPIX_EVENT_PIX3BLOB_V2, data, size);
+}
+
+
+inline void PIXInsertGPUMarkerOnContextForSetMarker(_In_ ID3D12GraphicsCommandList* commandList, UINT8 eventType, _In_reads_bytes_(size) void* data, UINT size)
+{
+    UNREFERENCED_PARAMETER(eventType);
+    commandList->SetMarker(WINPIX_EVENT_PIX3BLOB_V2, data, size);
+}
+
+inline void PIXInsertGPUMarkerOnContextForEndEvent(_In_ ID3D12GraphicsCommandList* commandList, UINT8, void*, UINT)
+{
+    commandList->EndEvent();
+}
+
+#pragma endregion
+
+#pragma region PixEvents
+    static constexpr uint64_t PixEventMaxSizeQwords = 255; //8 bit encoding for eventSize in PIX event header
+    static constexpr uint64_t PixEventHeaderSizeQwords = 3; //format: <eventHeader, color, context> <str content>
+    static constexpr uint64_t PixEventMaxPayloadSizeQwords = PixEventMaxSizeQwords - PixEventHeaderSizeQwords;
+
+//Borrowed from PIXEvents.h
+    void EncodePIXBeginEvent(ID3D12GraphicsCommandList* context, std::uint64_t color, const std::string& str)
+    {
+        //Small buffer optimization. Use 64 byte stack space
+        static constexpr auto StrStoreSpaceQwordsAvail = (8 - PixEventHeaderSizeQwords);
+        std::uint64_t buffer[8];
+
+        std::uint64_t* destination = buffer;
+        std::uint8_t* pBufferBegin = (std::uint8_t*)buffer;
+        std::uint8_t* pBufferEnd = pBufferBegin + sizeof(buffer) - 1;
+
+        //Need to store the null termination
+        auto strSizeBytes = std::min(PixEventMaxPayloadSizeQwords * 8, str.size() + 1);
+        //String size rounded up to QWORDS
+        auto strSizeQwords = (strSizeBytes + 7) / 8;
+
+        std::vector<std::uint64_t> largeBuffer;
+        if(StrStoreSpaceQwordsAvail < strSizeQwords) {
+            largeBuffer.resize(strSizeQwords + PixEventHeaderSizeQwords, 0);
+            destination = largeBuffer.data();
+            pBufferBegin = (std::uint8_t*)largeBuffer.data();
+            pBufferEnd = pBufferBegin + largeBuffer.size() * 8 - 1;
+        }
+        
+        std::uint8_t eventSizeQwords = strSizeQwords + PixEventHeaderSizeQwords;
+
+        {
+            std::uint64_t* eventDestination = destination++;
+            *destination++ = color;
+
+            //PIXCopyStringArgumentsWithContext(destination, limit, context, formatString, args...);
+            *destination++ = (uintptr_t)context;
+
+            //Clamp if string is too long
+            memcpy(destination, str.data(), strSizeBytes);
+
+            //Add null terminator
+            *pBufferEnd = 0;
+
+            const std::uint8_t eventMetadata =
+                PIX_EVENT_METADATA_ON_CONTEXT |
+                PIX_EVENT_METADATA_STRING_IS_ANSI |
+                PIX_EVENT_METADATA_HAS_COLOR;
+
+            *eventDestination = PIXEncodeEventInfo(0, PIXEvent_BeginEvent, eventSizeQwords, eventMetadata);
+
+            PIXInsertGPUMarkerOnContextForBeginEvent(
+                context,
+                PIXEvent_BeginEvent,
+                /*data*/pBufferBegin, 
+                /*size*/eventSizeQwords * 8
+            );
+
+        }
+    }
+
+    void EncodePIXEndEvent(ID3D12GraphicsCommandList* context)
+    {
+        std::uint64_t* destination = nullptr;
+
+        {
+            std::uint64_t buffer[8];
+            destination = buffer;
+
+            std::uint64_t* eventDestination = destination++;
+
+            const std::uint8_t eventSize = static_cast<const std::uint8_t>(destination - buffer);
+            const std::uint8_t eventMetadata = PIX_EVENT_METADATA_NONE;
+            *eventDestination = PIXEncodeEventInfo(0, PIXEvent_EndEvent, eventSize, eventMetadata);
+            PIXInsertGPUMarkerOnContextForEndEvent(context, PIXEvent_EndEvent, static_cast<void*>(buffer), static_cast<UINT>(reinterpret_cast<BYTE*>(destination) - reinterpret_cast<BYTE*>(buffer)));
+
+        }
+    }
+
+    void EncodePIXMarker(ID3D12GraphicsCommandList* context, std::uint64_t color, const std::string& str)
+    {
+        //Small buffer optimization. Use 64 byte stack space
+        static constexpr auto StrStoreSpaceQwordsAvail = (8 - PixEventHeaderSizeQwords);
+        std::uint64_t buffer[8];
+
+        std::uint64_t* destination = buffer;
+        std::uint8_t* pBufferBegin = (std::uint8_t*)buffer;
+        std::uint8_t* pBufferEnd = pBufferBegin + sizeof(buffer) - 1;
+
+        //Need to store the null termination
+        auto strSizeBytes = std::min(PixEventMaxPayloadSizeQwords * 8, str.size() + 1);
+        //String size rounded up to QWORDS
+        auto strSizeQwords = (strSizeBytes + 7) / 8;
+
+        std::vector<std::uint64_t> largeBuffer;
+        if(StrStoreSpaceQwordsAvail < strSizeQwords) {
+            largeBuffer.resize(strSizeQwords + PixEventHeaderSizeQwords, 0);
+            destination = largeBuffer.data();
+            pBufferBegin = (std::uint8_t*)largeBuffer.data();
+            pBufferEnd = pBufferBegin + largeBuffer.size() * 8 - 1;
+        }
+        
+        std::uint8_t eventSizeQwords = strSizeQwords + PixEventHeaderSizeQwords;
+
+
+        {
+            std::uint64_t* eventDestination = destination++;
+            *destination++ = color;
+
+            //PIXCopyStringArgumentsWithContext(destination, limit, context, formatString, args...);
+            *destination++ = (uintptr_t)context;
+
+            //Clamp if string is too long
+            memcpy(destination, str.data(), strSizeBytes);
+
+            //Add null terminator
+            *pBufferEnd = 0;
+
+            const std::uint8_t eventMetadata =
+                PIX_EVENT_METADATA_ON_CONTEXT |
+                PIX_EVENT_METADATA_STRING_IS_ANSI |
+                PIX_EVENT_METADATA_HAS_COLOR;
+            *eventDestination = PIXEncodeEventInfo(0, PIXEvent_SetMarker, eventSizeQwords, eventMetadata);
+            PIXInsertGPUMarkerOnContextForSetMarker(
+                context,
+                PIXEvent_SetMarker, 
+                /*data*/pBufferBegin, 
+                /*size*/eventSizeQwords * 8
+            );
+
+        }
+    }
+
+
+#pragma endregion
+
+
+}

--- a/src/backend/dx12/D3DPixEventEncoder.hpp
+++ b/src/backend/dx12/D3DPixEventEncoder.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+
+#include "d3d12.h"
+
+namespace alloy::dxc
+{
+    void EncodePIXBeginEvent(ID3D12GraphicsCommandList* context, std::uint64_t color, const std::string& str);
+    void EncodePIXEndEvent(ID3D12GraphicsCommandList* context);
+    void EncodePIXMarker(ID3D12GraphicsCommandList* context, std::uint64_t color, const std::string& str);
+} // namespace alloy::dxc
+

--- a/src/backend/dx12/DXCBindableResource.cpp
+++ b/src/backend/dx12/DXCBindableResource.cpp
@@ -4,6 +4,7 @@
 #include "D3DTypeCvt.hpp"
 #include "DXCDevice.hpp"
 #include "DXCTexture.hpp"
+#include "DXCContext.hpp"
 
 #include <stdexcept>
 #include <d3d12.h>
@@ -14,6 +15,7 @@ namespace alloy::dxc
     common::sp<IResourceLayout> DXCResourceLayout::Make(const common::sp<DXCDevice> &dev, const Description &desc)
     {
         auto pDev = dev->GetDevice();
+        auto& d3d12Dll = dev->GetContext().GetD3D12Dll();
 
         IShader::Stages combinedShaderResAccess;
         IShader::Stages samplerAccess;
@@ -115,7 +117,7 @@ namespace alloy::dxc
                           | D3D12_ROOT_SIGNATURE_FLAG_ALLOW_STREAM_OUTPUT;
 
         Microsoft::WRL::ComPtr<ID3DBlob> signature;
-        auto hr = D3D12SerializeRootSignature(&rootSigDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, nullptr);
+        auto hr = d3d12Dll.pfnD3D12SerializeRootSignature(&rootSigDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signature, nullptr);
         if (FAILED(hr))
         {
             return nullptr;

--- a/src/backend/dx12/DXCCommandList.cpp
+++ b/src/backend/dx12/DXCCommandList.cpp
@@ -13,11 +13,14 @@
 #include "DXCBindableResource.hpp"
 #include "d3d12.h"
 
-#define USE_PIX
-#include <WinPixEventRuntime/pix3.h>
+#include "D3DPixEventEncoder.hpp"
+
+//#define USE_PIX
+//#include <WinPixEventRuntime/pix3.h>
 
 namespace alloy::dxc
 {
+
 
     constexpr D3D12_RESOURCE_STATES RESOURCE_STATE_ALL_WRITE_BITS =
         D3D12_RESOURCE_STATE_RENDER_TARGET          |
@@ -86,7 +89,8 @@ namespace alloy::dxc
     //#define CHK_RENDERPASS_ENDED() DEBUGCODE(assert(_currentPass == nullptr))
     #define CHK_PIPELINE_SET() DEBUGCODE(assert(_currentPipeline != nullptr))
 
-    
+#pragma region CmdEncBase
+
     ID3D12GraphicsCommandList1* DXCCmdEncBase::GetCmdList() const {
         return static_cast<ID3D12GraphicsCommandList1*>(cmdList->GetHandle());
     }
@@ -250,28 +254,27 @@ namespace alloy::dxc
     //Sadly this can't be made constexpr due to std::floor can't be constexpr
     static uint32_t Color4fToPixColor(const Color4f& c4f) {
 
-        uint8_t r = std::floor(c4f.r * 255);
-        uint8_t g = std::floor(c4f.g * 255);
-        uint8_t b = std::floor(c4f.b * 255);
-        
-        return PIX_COLOR(r, g, b);
+        uint32_t r = std::floor(c4f.r * 255);
+        uint32_t g = std::floor(c4f.g * 255);
+        uint32_t b = std::floor(c4f.b * 255);
+        return 0xff000000u | (r << 16) | (g << 8) | b;
     }
     
     void DXCCmdEncBase::PushDebugGroup(const std::string& name, uint32_t color) {
         recordedCmds.emplace_back([this, name, color]() {
-            PIXBeginEvent(GetCmdList(), color, name.c_str());
+            EncodePIXBeginEvent(GetCmdList(), color, name);
         });
     }
 
     void DXCCmdEncBase::PopDebugGroup() {
         recordedCmds.emplace_back([this]() {
-            PIXEndEvent(GetCmdList());
+            EncodePIXEndEvent(GetCmdList());
         });
     }
 
     void DXCCmdEncBase::InsertDebugMarker(const std::string& name, uint32_t color) {
         recordedCmds.emplace_back([this, name, color]() {
-            PIXSetMarker(GetCmdList(), color, name.c_str());
+            EncodePIXMarker(GetCmdList(), color, name);
         });
     }
 
@@ -281,6 +284,11 @@ namespace alloy::dxc
         }
         recordedCmds.clear();
     }
+
+#pragma endregion
+
+
+#pragma region RenderCmdEnc
 
     DXCRenderCmdEnc::DXCRenderCmdEnc(
         DXCDevice *dev, 
@@ -699,79 +707,6 @@ namespace alloy::dxc
         });
     }
 
-    void DXCComputeCmdEnc::SetPipeline(const common::sp<IComputePipeline>& pipeline){
-
-        auto dxcPipeline = PtrCast<DXCComputePipeline>(pipeline.get());
-        assert(dxcPipeline != _currentPipeline);
-        resources.insert(pipeline);
-
-        recordedCmds.emplace_back([dxcPipeline, this]() {
-            dxcPipeline->CmdBindPipeline(GetCmdList());
-        });
-
-        //ensure resource set counts
-        //auto setCnt = vkPipeline->GetResourceSetCount();
-        //if (setCnt > _resourceSets.size()) {
-        //    _resourceSets.resize(setCnt, {});
-        //}
-
-        //Mark current pipeline
-        _currentPipeline = dxcPipeline;
-    }
-        
-    void DXCComputeCmdEnc::SetComputeResourceSet(const common::sp<IResourceSet>& rs){
-        CHK_PIPELINE_SET();
-        //assert(slot < _resourceSets.size());
-
-        auto dxcLayout = _currentPipeline->GetPipelineLayout();
-
-        resources.insert(rs);
-
-        auto d3dkrs = PtrCast<DXCResourceSet>(rs.get());
-
-        RegisterResourceSet(d3dkrs);
-
-        recordedCmds.emplace_back([d3dkrs, this]() {
-            auto& heaps = d3dkrs->GetHeaps();
-            GetCmdList()->SetDescriptorHeaps(heaps.size(), heaps.data());
-
-            for(uint32_t i = 0; i < heaps.size(); i++) {
-                GetCmdList()->SetComputeRootDescriptorTable(i, heaps[i]->GetGPUDescriptorHandleForHeapStart());
-            }
-        });
-    }
-
-        
-    void DXCComputeCmdEnc::SetPushConstants(
-        std::uint32_t pushConstantIndex,
-        const std::span<uint32_t>& data,
-        std::uint32_t destOffsetIn32BitValues
-    ) {
-        CHK_PIPELINE_SET();
-        //assert(slot < _resourceSets.size());
-
-        auto dxcLayout = _currentPipeline->GetPipelineLayout();
-
-        auto argBase = dxcLayout->GetHeapCount();
-
-        std::vector<uint32_t> dataCopy(data.begin(), data.end());
-
-        recordedCmds.emplace_back([
-            pushConstantIndex, 
-            argBase, 
-            data = std::move(dataCopy), 
-            destOffsetIn32BitValues, 
-            this
-        ]() {
-            GetCmdList()->SetComputeRoot32BitConstants(
-                pushConstantIndex + argBase,
-                data.size(),
-                data.data(),
-                destOffsetIn32BitValues
-            );
-        });
-    }
-
 
     void DXCRenderCmdEnc::SetViewports(const std::span<Viewport>& viewport){
         //dx12 requires all viewports set as an atomic operation.
@@ -890,6 +825,9 @@ namespace alloy::dxc
             GetCmdList()->DrawIndexedInstanced(indexCount, instanceCount, indexStart, vertexOffset, instanceStart);
         });
     }
+
+#pragma endregion RenderCmdEnc
+
     
 #if 0
     void DXCRenderCmdEnc::DrawIndirect(
@@ -925,6 +863,80 @@ namespace alloy::dxc
     }
 #endif
     
+#pragma region ComputeCmdEnc
+
+    void DXCComputeCmdEnc::SetPipeline(const common::sp<IComputePipeline>& pipeline){
+
+        auto dxcPipeline = PtrCast<DXCComputePipeline>(pipeline.get());
+        assert(dxcPipeline != _currentPipeline);
+        resources.insert(pipeline);
+
+        recordedCmds.emplace_back([dxcPipeline, this]() {
+            dxcPipeline->CmdBindPipeline(GetCmdList());
+        });
+
+        //ensure resource set counts
+        //auto setCnt = vkPipeline->GetResourceSetCount();
+        //if (setCnt > _resourceSets.size()) {
+        //    _resourceSets.resize(setCnt, {});
+        //}
+
+        //Mark current pipeline
+        _currentPipeline = dxcPipeline;
+    }
+        
+    void DXCComputeCmdEnc::SetComputeResourceSet(const common::sp<IResourceSet>& rs){
+        CHK_PIPELINE_SET();
+        //assert(slot < _resourceSets.size());
+
+        auto dxcLayout = _currentPipeline->GetPipelineLayout();
+
+        resources.insert(rs);
+
+        auto d3dkrs = PtrCast<DXCResourceSet>(rs.get());
+
+        RegisterResourceSet(d3dkrs);
+
+        recordedCmds.emplace_back([d3dkrs, this]() {
+            auto& heaps = d3dkrs->GetHeaps();
+            GetCmdList()->SetDescriptorHeaps(heaps.size(), heaps.data());
+
+            for(uint32_t i = 0; i < heaps.size(); i++) {
+                GetCmdList()->SetComputeRootDescriptorTable(i, heaps[i]->GetGPUDescriptorHandleForHeapStart());
+            }
+        });
+    }
+
+        
+    void DXCComputeCmdEnc::SetPushConstants(
+        std::uint32_t pushConstantIndex,
+        const std::span<uint32_t>& data,
+        std::uint32_t destOffsetIn32BitValues
+    ) {
+        CHK_PIPELINE_SET();
+        //assert(slot < _resourceSets.size());
+
+        auto dxcLayout = _currentPipeline->GetPipelineLayout();
+
+        auto argBase = dxcLayout->GetHeapCount();
+
+        std::vector<uint32_t> dataCopy(data.begin(), data.end());
+
+        recordedCmds.emplace_back([
+            pushConstantIndex, 
+            argBase, 
+            data = std::move(dataCopy), 
+            destOffsetIn32BitValues, 
+            this
+        ]() {
+            GetCmdList()->SetComputeRoot32BitConstants(
+                pushConstantIndex + argBase,
+                data.size(),
+                data.data(),
+                destOffsetIn32BitValues
+            );
+        });
+    }
 
     void DXCComputeCmdEnc::Dispatch(
         std::uint32_t groupCountX, std::uint32_t groupCountY, std::uint32_t groupCountZ
@@ -965,6 +977,12 @@ namespace alloy::dxc
         //vkCmdDispatchIndirect(_cmdBuf, vkBuffer->GetHandle(), offset);
     };
 #endif
+
+
+#pragma endregion ComputeCmdEnc
+
+
+#pragma region XferCmdEnc
 
 #if 0
     static uint32_t _ComputeSubresource(uint32_t mipLevel, uint32_t mipLevelCount, uint32_t arrayLayer)
@@ -1195,6 +1213,11 @@ namespace alloy::dxc
     void DXCTransferCmdEnc::GenerateMipmaps(const common::sp<ITexture>& texture){
         ///#TODO: remove this function as mipmap generation needs more flexiblity in infcanvas
     }
+
+#pragma endregion XferCmdEnc
+
+
+#pragma region CmdList
 
     DXCCommandList::~DXCCommandList(){
         for(auto* p : _passes) {
@@ -1782,6 +1805,8 @@ namespace alloy::dxc
         auto pixColor = Color4fToPixColor(color);
         _currentPass->InsertDebugMarker(name, pixColor);
     };
+
+#pragma endregion CmdList
 
     static void _PopulateTextureBarrier(const alloy::TextureBarrierResource& desc,
                                               D3D12_TEXTURE_BARRIER& barrier

--- a/src/backend/dx12/DXCContext.cpp
+++ b/src/backend/dx12/DXCContext.cpp
@@ -5,6 +5,9 @@
 #include "DXCDevice.hpp"
 
 #include <iostream>
+#include <stdexcept>
+#include <format>
+#include <string>
 
 namespace alloy {
     
@@ -15,9 +18,141 @@ namespace alloy {
 
 namespace alloy::dxc {
 
-    void PrintDxErrorMsg() {
-        IDXGIDebug1* dxgiDebug;
-        if (SUCCEEDED(DXGIGetDebugInterface1(0, IID_PPV_ARGS(&dxgiDebug))))
+
+    DllLoader::DllLoader(const char* dllName) 
+        : dllHandle(LoadLibraryA(dllName))
+    {
+        if(!dllHandle)
+            throw std::runtime_error(std::format("Load dll {} failed", dllName));
+    }
+
+    DllLoader::~DllLoader() {
+        if(dllHandle) {
+            FreeLibrary((HMODULE)dllHandle);
+        }
+    }
+
+    void* DllLoader::GetFunctionEntry(const char* name) {
+        return (void*)GetProcAddress((HMODULE)dllHandle, name);
+    }
+
+
+    D3D12DllLoader::D3D12DllLoader() 
+        : DllLoader("d3d12.dll")
+        , pfnD3D12CreateDevice(nullptr)
+        , pfnD3D12GetDebugInterface(nullptr)
+        , pfnD3D12SerializeRootSignature(nullptr)
+        , pfnD3D12SerializeVersionedRootSignature(nullptr)
+    {
+        pfnD3D12CreateDevice = (PFN_D3D12_CREATE_DEVICE)GetFunctionEntry("D3D12CreateDevice");
+        pfnD3D12GetDebugInterface = (PFN_D3D12_GET_DEBUG_INTERFACE)GetFunctionEntry("D3D12GetDebugInterface");
+        pfnD3D12SerializeRootSignature
+            = (PFN_D3D12_SERIALIZE_ROOT_SIGNATURE)GetFunctionEntry("D3D12SerializeRootSignature");
+        pfnD3D12SerializeVersionedRootSignature 
+            = (PFN_D3D12_SERIALIZE_VERSIONED_ROOT_SIGNATURE)GetFunctionEntry("D3D12SerializeVersionedRootSignature");
+        
+    }
+    
+    DxgiDllLoader::DxgiDllLoader() 
+        : DllLoader("dxgi.dll")
+        , pfnCreateDXGIFactory2(nullptr)
+        , pfnDXGIGetDebugInterface1(nullptr)
+    {
+        pfnCreateDXGIFactory2 = (PFN_CreateDXGIFactory2)GetFunctionEntry("CreateDXGIFactory2");
+        pfnDXGIGetDebugInterface1 
+            = (PFN_DXGIGetDebugInterface1)GetFunctionEntry("DXGIGetDebugInterface1");
+    }
+
+    AgilitySDKLoader::AgilitySDKLoader(bool loadDebugLayer)
+        : d3d12CoreDllHandle(nullptr)
+        , d3d12SDKLayersDllHandle(nullptr)
+        , d3d12CoreVersion(0)
+        , d3d12SDKLayersVersion(0)
+    {
+        //Get buffer length
+        DWORD reqWCharCnt = GetCurrentDirectoryW(0, nullptr);
+        std::wstring cwd(reqWCharCnt, L'\0');
+        //Get data
+        GetCurrentDirectoryW(reqWCharCnt, cwd.data());
+
+        //GetCurrentDirectoryW returns content size WITH null terminator if
+        //all args are null ???
+        while(!cwd.empty() && cwd.ends_with(L'\0')) {
+            cwd.pop_back();
+        }
+
+        //Append slashes at end
+        if(!cwd.ends_with(L'\\')) {
+            cwd += L'\\';
+        }
+
+        //Search "<CWD>/D3D12/"
+        auto dllSearchPath = cwd + L"D3D12\\";
+        {
+            auto dllLoadPath = dllSearchPath + L"D3D12Core.dll";
+            d3d12CoreDllHandle = LoadLibraryW(dllLoadPath.c_str());
+        }
+
+        // Search <CWD>
+        if(!d3d12CoreDllHandle) {
+            dllSearchPath = cwd;
+            auto dllLoadPath = dllSearchPath + L"D3D12Core.dll";
+            d3d12CoreDllHandle = LoadLibraryW(dllLoadPath.c_str());
+        }
+
+        //Search default paths
+        if(!d3d12CoreDllHandle) {
+            dllSearchPath = L"";
+            auto dllLoadPath = dllSearchPath + L"D3D12Core.dll";
+            d3d12CoreDllHandle = LoadLibraryW(dllLoadPath.c_str());
+        }
+
+        if(d3d12CoreDllHandle) {
+            {
+                //Extract D3D12SDKVersion variable from dll
+                auto pSDKVer = (uint32_t*)GetProcAddress((HMODULE)d3d12CoreDllHandle, "D3D12SDKVersion");
+                //An not-matching dll may not have this field
+                if(pSDKVer) {
+                    d3d12CoreVersion = *pSDKVer;
+                }
+
+                std::cout << std::format("AgilitySDK D3D12Core.dll version {}\n", d3d12CoreVersion);
+                    
+            }
+
+            //Load d3d12SDKLayers.dll from same path as D3D12Core.dll's
+            if(loadDebugLayer) {
+                auto dllLoadPath = dllSearchPath + L"d3d12SDKLayers.dll";
+                d3d12SDKLayersDllHandle = LoadLibraryW(dllLoadPath.c_str());
+                if(d3d12SDKLayersDllHandle) {
+                    //Extract D3D12SDKVersion variable from dll
+                    auto pSDKVer = (uint32_t*)GetProcAddress((HMODULE)d3d12SDKLayersDllHandle, "D3D12SDKVersion");
+                    //An not-matching dll may not have this field
+                    if(pSDKVer) {
+                        d3d12SDKLayersVersion = *pSDKVer;
+                    }
+
+                    std::cout << std::format("AgilitySDK d3d12SDKLayers.dll version {}\n", d3d12SDKLayersVersion);
+
+                    if(d3d12SDKLayersVersion != d3d12CoreVersion) {
+                        std::cout << std::format("Version mismatch between AgilitySDK D3D12Core.dll (version {}) and d3d12SDKLayers.dll (version {}), CreateDevice may fail!\n", d3d12CoreVersion, d3d12SDKLayersVersion);
+                    }
+                }
+            }
+        }
+    }
+
+    AgilitySDKLoader::~AgilitySDKLoader() {
+        if(d3d12CoreDllHandle) {
+            FreeLibrary((HMODULE)d3d12CoreDllHandle);
+        }
+        if(d3d12SDKLayersDllHandle) {
+            FreeLibrary((HMODULE)d3d12SDKLayersDllHandle);
+        }
+    }
+
+    void PrintDxErrorMsg(IDXGIDebug1* dxgiDebug) {
+        //if (SUCCEEDED(DXGIGetDebugInterface1(0, IID_PPV_ARGS(&dxgiDebug))))
         {
             IDXGIInfoQueue* dxgiInfoQueue;
             ThrowIfFailed(dxgiDebug->QueryInterface(IID_PPV_ARGS(&dxgiInfoQueue)));
@@ -36,6 +171,102 @@ namespace alloy::dxc {
             dxgiInfoQueue->Release();
             dxgiDebug->Release();
         }
+    }
+
+    
+    void D3D12DevCaps::ReadFromDevice(ID3D12Device* pdev)
+    {
+        *this = { };
+
+        D3D_FEATURE_LEVEL checklist[] = {
+            D3D_FEATURE_LEVEL_11_0,
+            D3D_FEATURE_LEVEL_11_1,
+            D3D_FEATURE_LEVEL_12_0,
+            D3D_FEATURE_LEVEL_12_1,
+            D3D_FEATURE_LEVEL_12_2,
+        };
+
+        D3D12_FEATURE_DATA_FEATURE_LEVELS levels = {
+            _countof(checklist),
+            checklist
+        };
+
+        if(SUCCEEDED(pdev->CheckFeatureSupport(D3D12_FEATURE_FEATURE_LEVELS, &levels, sizeof(levels)))){
+            feature_level = levels.MaxSupportedFeatureLevel;
+        }
+
+        D3D12_FEATURE_DATA_SHADER_MODEL shader_model{};
+        shader_model.HighestShaderModel = D3D_SHADER_MODEL_6_7;
+        if(SUCCEEDED(pdev->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL, &shader_model, sizeof(shader_model)))){
+            this->shader_model = shader_model.HighestShaderModel;
+        }
+
+        D3D12_FEATURE_DATA_ROOT_SIGNATURE root_sig{};
+        root_sig.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+        if(SUCCEEDED(pdev->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &root_sig, sizeof(root_sig)))){
+            root_sig_version = root_sig.HighestVersion;
+        }
+
+
+        pdev->CheckFeatureSupport(D3D12_FEATURE_ARCHITECTURE1, &architecture, sizeof(architecture));
+        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
+        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &options1, sizeof(options1));
+        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS2, &options2, sizeof(options2));
+        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS3, &options3, sizeof(options3));
+        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS4, &options4, sizeof(options4));
+        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS7, &options7, sizeof(options7));
+        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS12, &options12, sizeof(options12));
+        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS13, &options13, sizeof(options13));
+        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS14, &options14, sizeof(options14));
+        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS15, &options15, sizeof(options15));
+        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS16, &options16, sizeof(options16));
+        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS17, &options17, sizeof(options17));
+        if (FAILED(pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS19, &options19, sizeof(options19)))) {
+            options19.MaxSamplerDescriptorHeapSize = D3D12_MAX_SHADER_VISIBLE_SAMPLER_HEAP_SIZE;
+            options19.MaxSamplerDescriptorHeapSizeWithStaticSamplers = options19.MaxSamplerDescriptorHeapSize;
+            options19.MaxViewDescriptorHeapSize = D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1;
+        }
+        {
+            D3D12_FEATURE_DATA_FORMAT_SUPPORT a4b4g4r4_support = {
+                DXGI_FORMAT_A4B4G4R4_UNORM
+            };
+            support_a4b4g4r4 =
+             SUCCEEDED(pdev->CheckFeatureSupport(D3D12_FEATURE_FORMAT_SUPPORT, &a4b4g4r4_support, sizeof(a4b4g4r4_support)));
+        }
+
+        //Query usable sample qualities
+        maxMSAASampleCount = 1;
+        for(uint32_t sampleCount : {32, 16, 8, 4, 2}) {
+            D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS queryData {
+                .Format = DXGI_FORMAT::DXGI_FORMAT_R8G8B8A8_UNORM,
+                .SampleCount = sampleCount
+            };
+            pdev->CheckFeatureSupport(D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS
+                , &queryData, sizeof(queryData)
+            );
+
+            if(queryData.NumQualityLevels != 0) {
+                maxMSAASampleCount = sampleCount;
+                break;
+            }
+        }
+
+        D3D12_COMMAND_QUEUE_DESC queue_desc = {
+           /*.Type =*/ D3D12_COMMAND_LIST_TYPE_DIRECT,
+           /*.Priority =*/ D3D12_COMMAND_QUEUE_PRIORITY_NORMAL,
+           /*.Flags =*/ D3D12_COMMAND_QUEUE_FLAG_NONE,
+           /*.NodeMask =*/ 0,
+        };
+ 
+        ID3D12CommandQueue *cmdqueue;
+        pdev->CreateCommandQueue(&queue_desc,
+                                 IID_ID3D12CommandQueue,
+                                 (void **)&cmdqueue);
+ 
+        uint64_t ts_freq;
+        cmdqueue->GetTimestampFrequency(&ts_freq);
+        timestamp_period = 1000000000.0f / ts_freq;
+        cmdqueue->Release();
     }
 
     common::sp<IGraphicsDevice> DXCAdapter::RequestDevice(
@@ -62,8 +293,7 @@ namespace alloy::dxc {
 
         ThrowIfFailed(D3D12CreateDevice(_adp, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&dev)));
 
-        D3D12DevCaps caps {};
-        caps.ReadFromDevice(dev);
+        _caps.ReadFromDevice(dev);
 
         dev->Release();
 
@@ -90,6 +320,10 @@ namespace alloy::dxc {
                     if (required_size == 0) break;
         
                     WideCharToMultiByte(CP_UTF8, 0, desc.Description, -1, devNameStr.data(), required_size, NULL, NULL);
+                    //Trim null terminators
+                    while(devNameStr.ends_with('\0')) {
+                        devNameStr.pop_back();
+                    }
                 }while(0);
         
         
@@ -103,7 +337,7 @@ namespace alloy::dxc {
             
             auto& apiVer = info.apiVersion;
             apiVer = {Backend::DX12};
-            switch (caps.feature_level)
+            switch (_caps.feature_level)
             {
             case D3D_FEATURE_LEVEL_12_2:apiVer.major = 12; apiVer.minor = 2; break;
             case D3D_FEATURE_LEVEL_12_1:apiVer.major = 12; apiVer.minor = 1; break;
@@ -125,7 +359,7 @@ namespace alloy::dxc {
             if(SUCCEEDED(_adp->GetDesc1(&desc))){
                 auto& localSeg = info.memSegments.emplace_back();
                 localSeg.sizeInBytes = desc.DedicatedVideoMemory;
-                if(caps.SupportReBAR() || caps.SupportUMA()) {
+                if(_caps.SupportReBAR() || _caps.SupportUMA()) {
                     localSeg.flags.isCPUVisible = 1;
                 }
 
@@ -136,14 +370,16 @@ namespace alloy::dxc {
             }
         }
 
-        info.capabilities.isUMA = caps.SupportUMA();
-        info.capabilities.supportMeshShader = caps.SupportMeshShader();
+        info.capabilities.isUMA = _caps.SupportUMA();
+        info.capabilities.supportMeshShader = _caps.SupportMeshShader();
+        info.capabilities.supportRayTracing = _caps.SupportRayTracing();
+        info.capabilities.supportResizableBar = _caps.SupportReBAR();
 
         uint32_t full_heap_count = D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1;
         uint32_t uav_count = 8;
-        switch(caps.ResourceBindingTier()){
+        switch(_caps.ResourceBindingTier()){
             case 1 : {
-                uav_count = caps.feature_level == D3D_FEATURE_LEVEL_11_0 ? 8 : 64;
+                uav_count = _caps.feature_level == D3D_FEATURE_LEVEL_11_0 ? 8 : 64;
                 full_heap_count = D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1;
             } break;
             case 2 : {
@@ -169,9 +405,9 @@ namespace alloy::dxc {
         //    .max_dynamic_uniform_buffers_per_pipeline_layout,
         //max_dynamic_storage_buffers_per_pipeline_layout: base
         //    .max_dynamic_storage_buffers_per_pipeline_layout,
-        info.limits.maxPerStageDescriptorSampledImages = caps.ResourceBindingTier() > 1 ? 
+        info.limits.maxPerStageDescriptorSampledImages = _caps.ResourceBindingTier() > 1 ? 
             full_heap_count : 128;
-        info.limits.maxPerStageDescriptorSamplers = caps.ResourceBindingTier() > 1 ? 
+        info.limits.maxPerStageDescriptorSamplers = _caps.ResourceBindingTier() > 1 ? 
             D3D12_MAX_SHADER_VISIBLE_SAMPLER_HEAP_SIZE : 16;
         // these both account towards `uav_count`, but we can't express the limit as as sum
         // of the two, so we divide it by 4 to account for the worst case scenario
@@ -243,17 +479,38 @@ namespace alloy::dxc {
         //max_buffer_size: i32::MAX as u64,
         //max_non_sampler_bindings: 1_000_000,
         
-        if     (caps.maxMSAASampleCount >= 32) info.limits.maxMSAASampleCount = SampleCount::x32;
-        else if(caps.maxMSAASampleCount >= 16) info.limits.maxMSAASampleCount = SampleCount::x16;
-        else if(caps.maxMSAASampleCount >= 8)  info.limits.maxMSAASampleCount = SampleCount::x8;
-        else if(caps.maxMSAASampleCount >= 4)  info.limits.maxMSAASampleCount = SampleCount::x4;
-        else if(caps.maxMSAASampleCount >= 2)  info.limits.maxMSAASampleCount = SampleCount::x2;
+        if     (_caps.maxMSAASampleCount >= 32) info.limits.maxMSAASampleCount = SampleCount::x32;
+        else if(_caps.maxMSAASampleCount >= 16) info.limits.maxMSAASampleCount = SampleCount::x16;
+        else if(_caps.maxMSAASampleCount >= 8)  info.limits.maxMSAASampleCount = SampleCount::x8;
+        else if(_caps.maxMSAASampleCount >= 4)  info.limits.maxMSAASampleCount = SampleCount::x4;
+        else if(_caps.maxMSAASampleCount >= 2)  info.limits.maxMSAASampleCount = SampleCount::x2;
         else                                   info.limits.maxMSAASampleCount = SampleCount::x1;
+
+        //DX12 can have any strides in a structured buffer;
+        info.limits.minStructuredBufferStride = 1;
     }
 
 
     
     common::sp<DXCContext> DXCContext::Make(const IContext::Options& opts) {
+        //Init Agility SDK first
+        AgilitySDKLoader agilitySDK {opts.debug};
+
+        //Load the relevant dlls:
+        //auto d3d12Dll = std::make_unique<D3D12DllLoader>();
+        std::unique_ptr<D3D12DllLoader> d3d12Dll;
+        std::unique_ptr<DxgiDllLoader> dxgiDll;
+
+        try {
+            d3d12Dll = std::make_unique<D3D12DllLoader>();
+            dxgiDll = std::make_unique<DxgiDllLoader>();
+        }
+        catch(const std::runtime_error& e) {
+            //Failed to load dll
+            return nullptr;
+        }
+
+
         UINT dxgiFactoryFlags = 0;
         // Enable the debug layer (requires the Graphics Tools "optional feature").
         // NOTE: Enabling the debug layer after device creation will invalidate the active device.
@@ -261,7 +518,7 @@ namespace alloy::dxc {
 //#ifndef NDEBUG
             // Enable the debug layer.
             ID3D12Debug* debugController;
-            if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
+            if (SUCCEEDED(d3d12Dll->pfnD3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
             {
                 debugController->EnableDebugLayer();
 
@@ -275,7 +532,7 @@ namespace alloy::dxc {
             }
 
             IDXGIInfoQueue* dxgiInfoQueue;
-            if (SUCCEEDED(DXGIGetDebugInterface1(0, IID_PPV_ARGS(&dxgiInfoQueue))))
+            if (SUCCEEDED(dxgiDll->pfnDXGIGetDebugInterface1(0, IID_PPV_ARGS(&dxgiInfoQueue))))
             {
                 dxgiInfoQueue->SetBreakOnSeverity(DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE_SEVERITY_ERROR, true);
                 dxgiInfoQueue->SetBreakOnSeverity(DXGI_DEBUG_ALL, DXGI_INFO_QUEUE_MESSAGE_SEVERITY_CORRUPTION, true);
@@ -284,19 +541,20 @@ namespace alloy::dxc {
         }
         //Create DXGIFactory
         IDXGIFactory4* dxgiFactory;
-        auto status = CreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&dxgiFactory));
+        auto status = dxgiDll->pfnCreateDXGIFactory2(dxgiFactoryFlags, IID_PPV_ARGS(&dxgiFactory));
         if(FAILED(status)) {
             return nullptr;
         }
 
-        return common::sp(new DXCContext(dxgiFactory));
+        return common::sp(new DXCContext(
+            std::move(agilitySDK),
+            std::move(*d3d12Dll),
+            std::move(*dxgiDll),
+            dxgiFactory
+        ));
     }
 
     
-    DXCContext::DXCContext(IDXGIFactory4* factory)
-        : _factory(factory)
-    { }
-       
     DXCContext::~DXCContext() {
         _factory->Release();
 
@@ -304,7 +562,7 @@ namespace alloy::dxc {
 #ifndef NDEBUG
         {
             IDXGIDebug1* dxgiDebug;
-            if (SUCCEEDED(DXGIGetDebugInterface1(0, IID_PPV_ARGS(&dxgiDebug))))
+            if (SUCCEEDED(_dxgiDll.pfnDXGIGetDebugInterface1(0, IID_PPV_ARGS(&dxgiDebug))))
             {
                 dxgiDebug->ReportLiveObjects(DXGI_DEBUG_ALL,
                     DXGI_DEBUG_RLO_FLAGS(DXGI_DEBUG_RLO_SUMMARY | DXGI_DEBUG_RLO_IGNORE_INTERNAL));
@@ -355,7 +613,7 @@ namespace alloy::dxc {
             // Check to see if the adapter supports Direct3D 12,
             // but don't create the actual device yet.
             if (FAILED(
-                D3D12CreateDevice(adapter, D3D_FEATURE_LEVEL_12_0,
+                _d3d12Dll.pfnD3D12CreateDevice(adapter, D3D_FEATURE_LEVEL_12_0,
                     _uuidof(ID3D12Device), nullptr)))
             {
                 adapter->Release();

--- a/src/backend/dx12/DXCContext.hpp
+++ b/src/backend/dx12/DXCContext.hpp
@@ -12,6 +12,7 @@
 //standard library headers
 #include <string>
 #include <vector>
+#include <memory>
 //backend specific headers
 
 //platform specific headers
@@ -24,10 +25,154 @@ namespace alloy::dxc {
     class DXCDevice;
     class DXCContext;
 
+    class DllLoader {
+    protected:
+        void* dllHandle;
+
+    public:
+        DllLoader(const char* dllName);
+        virtual ~DllLoader();
+
+        DllLoader(const DllLoader&) = delete;
+        DllLoader& operator=(const DllLoader&) = delete;
+        
+        DllLoader(DllLoader&& other)
+            : dllHandle(other.dllHandle)
+        {
+            other.dllHandle = nullptr;
+        }
+        
+        DllLoader& operator=(DllLoader&& other) {
+            if(dllHandle) {
+                FreeLibrary((HMODULE)dllHandle);
+            }
+
+            dllHandle = other.dllHandle;
+            other.dllHandle = nullptr;
+        }
+
+
+        void* GetFunctionEntry(const char* name);
+    };
+
+    
+    class D3D12DllLoader : public DllLoader {
+    public:
+        PFN_D3D12_CREATE_DEVICE            pfnD3D12CreateDevice;
+        PFN_D3D12_GET_DEBUG_INTERFACE      pfnD3D12GetDebugInterface;
+        PFN_D3D12_SERIALIZE_ROOT_SIGNATURE pfnD3D12SerializeRootSignature;
+        PFN_D3D12_SERIALIZE_VERSIONED_ROOT_SIGNATURE pfnD3D12SerializeVersionedRootSignature;
+
+        D3D12DllLoader();
+    };
+
+    class DxgiDllLoader : public DllLoader {
+    public:
+        using PFN_CreateDXGIFactory2 = HRESULT (WINAPI* )(UINT ,REFIID , _COM_Outptr_ void** );
+        using PFN_DXGIGetDebugInterface1 = HRESULT (WINAPI *)(UINT ,REFIID, _COM_Outptr_ void **);
+
+        PFN_CreateDXGIFactory2 pfnCreateDXGIFactory2;
+        PFN_DXGIGetDebugInterface1 pfnDXGIGetDebugInterface1;
+
+        DxgiDllLoader();
+    };
+
+    //Special variant of DLL loader. Due to no direct usage of those dlls
+    // from D3D12Core.dll & d3d12SDKLayers.dll, we just open these without getting
+    // any function entries. Normally the agility SDK co-distributed with 
+    // the app is often newer that the OS's itself, we'll first try loading
+    // it in <App exe binary path>/D3D12/****.dll, if that fails then from OS
+    // default path
+    class AgilitySDKLoader {
+        void* d3d12CoreDllHandle,* d3d12SDKLayersDllHandle;
+        uint32_t d3d12CoreVersion, d3d12SDKLayersVersion;
+    public:
+        AgilitySDKLoader(bool loadDebugLayer = false);
+
+        ~AgilitySDKLoader();
+
+        AgilitySDKLoader(const AgilitySDKLoader&) = delete;
+        AgilitySDKLoader& operator=(const AgilitySDKLoader&) = delete;
+
+        
+        AgilitySDKLoader(AgilitySDKLoader&& other)
+            : d3d12CoreDllHandle(other.d3d12CoreDllHandle)
+            , d3d12SDKLayersDllHandle(other.d3d12SDKLayersDllHandle)
+            , d3d12CoreVersion(other.d3d12CoreVersion)
+            , d3d12SDKLayersVersion(other.d3d12SDKLayersVersion)
+        {
+            other.d3d12CoreDllHandle = nullptr;
+            other.d3d12SDKLayersDllHandle = nullptr;
+        }
+        AgilitySDKLoader& operator=(AgilitySDKLoader&& other) {
+            if(d3d12CoreDllHandle) {
+                FreeLibrary((HMODULE)d3d12CoreDllHandle);
+            }
+            if(d3d12SDKLayersDllHandle) {
+                FreeLibrary((HMODULE)d3d12SDKLayersDllHandle);
+            }
+
+            d3d12CoreDllHandle      = other.d3d12CoreDllHandle;
+            d3d12SDKLayersDllHandle = other.d3d12SDKLayersDllHandle;
+            d3d12CoreVersion        = other.d3d12CoreVersion;
+            d3d12SDKLayersVersion   = other.d3d12SDKLayersVersion;
+
+            other.d3d12CoreDllHandle = nullptr;
+            other.d3d12SDKLayersDllHandle = nullptr;
+        }
+
+        uint32_t GetSDKVersion() const { return d3d12CoreVersion; }
+        uint32_t GetDebugLayerVersion() const { return d3d12SDKLayersVersion; }
+    };
+
+      
+    struct D3D12DevCaps{
+        D3D_FEATURE_LEVEL feature_level;
+        D3D_SHADER_MODEL shader_model;
+        D3D_ROOT_SIGNATURE_VERSION root_sig_version;
+        D3D12_FEATURE_DATA_ARCHITECTURE1 architecture;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS options;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS1 options1;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS2 options2;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS3 options3;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS4 options4;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS5 options5;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS7 options7;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS12 options12;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS13 options13;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS14 options14;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS15 options15;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS16 options16;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS17 options17;
+        D3D12_FEATURE_DATA_D3D12_OPTIONS19 options19;
+
+        float timestamp_period;
+        bool support_a4b4g4r4;
+        uint32_t maxMSAASampleCount;
+
+        void ReadFromDevice(ID3D12Device* pdev);
+
+        bool SupportEnhancedBarrier() const { return options12.EnhancedBarriersSupported; }
+        bool SupportMeshShader() const {return options7.MeshShaderTier != D3D12_MESH_SHADER_TIER_NOT_SUPPORTED;}
+        bool SupportRayTracing() const {return options5.RaytracingTier != D3D12_RAYTRACING_TIER_NOT_SUPPORTED; }
+        bool SupportReBAR() const { return options16.GPUUploadHeapSupported; }
+        bool SupportUMA() const { return architecture.UMA || architecture.CacheCoherentUMA; }
+    
+        uint32_t ResourceBindingTier() const {
+            switch(options.ResourceBindingTier) {
+                case D3D12_RESOURCE_BINDING_TIER_3: return 3;
+                case D3D12_RESOURCE_BINDING_TIER_2: return 2;
+                case D3D12_RESOURCE_BINDING_TIER_1:
+                default: return 1;
+            }
+        }
+    };
 
     class DXCAdapter : public IPhysicalAdapter {
         IDXGIAdapter1* _adp;
         common::sp<DXCContext> _ctx;
+
+        D3D12DevCaps _caps;
 
         void PopulateAdpInfo();
 
@@ -36,6 +181,9 @@ namespace alloy::dxc {
 
         virtual ~DXCAdapter() override;
 
+        DXCContext& GetContext() { return *_ctx; }
+        const D3D12DevCaps& GetCaps() const { return _caps; }
+
         IDXGIAdapter1* GetHandle() const {return _adp;}
         virtual common::sp<IGraphicsDevice> RequestDevice(
             const IGraphicsDevice::Options& options) override;
@@ -43,14 +191,32 @@ namespace alloy::dxc {
     };
 
     class DXCContext : public IContext {
+        AgilitySDKLoader _agilitySDK;
+
+        D3D12DllLoader _d3d12Dll;
+        DxgiDllLoader _dxgiDll;
+
         IDXGIFactory4* _factory;
     public:
-        DXCContext(IDXGIFactory4* factory);
+        DXCContext(
+            AgilitySDKLoader&& agilitySDK,
+            D3D12DllLoader&& d3d12Dll,
+            DxgiDllLoader&& dxgiDll,
+            IDXGIFactory4* factory
+        ) 
+            : _agilitySDK(std::move(agilitySDK))
+            , _d3d12Dll(std::move(d3d12Dll))
+            , _dxgiDll(std::move(dxgiDll))
+            , _factory(factory)
+        { }
         virtual ~DXCContext() override;
 
         static common::sp<DXCContext> Make(const IContext::Options& opts);
 
         virtual common::sp<IGraphicsDevice> CreateDefaultDevice(const IGraphicsDevice::Options& options) override;
         virtual std::vector<common::sp<IPhysicalAdapter>> EnumerateAdapters() override;
+
+        const D3D12DllLoader& GetD3D12Dll() const { return _d3d12Dll; }
+        const DxgiDllLoader& GetDxgiDll() const { return _dxgiDll; }
     };
 }

--- a/src/backend/dx12/DXCDevice.cpp
+++ b/src/backend/dx12/DXCDevice.cpp
@@ -108,98 +108,6 @@ HRESULT GetAdapter(IDXGIFactory4* dxgiFactory, bool enableDebug, ComPtr<IDXGIAda
 
 namespace alloy::dxc {
 
-    void D3D12DevCaps::ReadFromDevice(ID3D12Device* pdev)
-    {
-        D3D_FEATURE_LEVEL checklist[] = {
-            D3D_FEATURE_LEVEL_11_0,
-            D3D_FEATURE_LEVEL_11_1,
-            D3D_FEATURE_LEVEL_12_0,
-            D3D_FEATURE_LEVEL_12_1,
-            D3D_FEATURE_LEVEL_12_2,
-        };
-
-        D3D12_FEATURE_DATA_FEATURE_LEVELS levels = {
-            _countof(checklist),
-            checklist
-        };
-
-        if(SUCCEEDED(pdev->CheckFeatureSupport(D3D12_FEATURE_FEATURE_LEVELS, &levels, sizeof(levels)))){
-            feature_level = levels.MaxSupportedFeatureLevel;
-        }
-
-        D3D12_FEATURE_DATA_SHADER_MODEL shader_model{};
-        shader_model.HighestShaderModel = D3D_SHADER_MODEL_6_7;
-        if(SUCCEEDED(pdev->CheckFeatureSupport(D3D12_FEATURE_SHADER_MODEL, &shader_model, sizeof(shader_model)))){
-            this->shader_model = shader_model.HighestShaderModel;
-        }
-
-        D3D12_FEATURE_DATA_ROOT_SIGNATURE root_sig{};
-        root_sig.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
-        if(SUCCEEDED(pdev->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &root_sig, sizeof(root_sig)))){
-            root_sig_version = root_sig.HighestVersion;
-        }
-
-
-        pdev->CheckFeatureSupport(D3D12_FEATURE_ARCHITECTURE1, &architecture, sizeof(architecture));
-        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS, &options, sizeof(options));
-        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS1, &options1, sizeof(options1));
-        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS2, &options2, sizeof(options2));
-        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS3, &options3, sizeof(options3));
-        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS4, &options4, sizeof(options4));
-        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS7, &options7, sizeof(options7));
-        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS12, &options12, sizeof(options12));
-        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS13, &options13, sizeof(options13));
-        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS14, &options14, sizeof(options14));
-        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS15, &options15, sizeof(options15));
-        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS16, &options16, sizeof(options16));
-        pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS17, &options17, sizeof(options17));
-        if (FAILED(pdev->CheckFeatureSupport(D3D12_FEATURE_D3D12_OPTIONS19, &options19, sizeof(options19)))) {
-            options19.MaxSamplerDescriptorHeapSize = D3D12_MAX_SHADER_VISIBLE_SAMPLER_HEAP_SIZE;
-            options19.MaxSamplerDescriptorHeapSizeWithStaticSamplers = options19.MaxSamplerDescriptorHeapSize;
-            options19.MaxViewDescriptorHeapSize = D3D12_MAX_SHADER_VISIBLE_DESCRIPTOR_HEAP_SIZE_TIER_1;
-        }
-        {
-            D3D12_FEATURE_DATA_FORMAT_SUPPORT a4b4g4r4_support = {
-                DXGI_FORMAT_A4B4G4R4_UNORM
-            };
-            support_a4b4g4r4 =
-             SUCCEEDED(pdev->CheckFeatureSupport(D3D12_FEATURE_FORMAT_SUPPORT, &a4b4g4r4_support, sizeof(a4b4g4r4_support)));
-        }
-
-        //Query usable sample qualities
-        maxMSAASampleCount = 1;
-        for(uint32_t sampleCount : {32, 16, 8, 4, 2}) {
-            D3D12_FEATURE_DATA_MULTISAMPLE_QUALITY_LEVELS queryData {
-                .Format = DXGI_FORMAT::DXGI_FORMAT_R8G8B8A8_UNORM,
-                .SampleCount = sampleCount
-            };
-            pdev->CheckFeatureSupport(D3D12_FEATURE_MULTISAMPLE_QUALITY_LEVELS
-                , &queryData, sizeof(queryData)
-            );
-
-            if(queryData.NumQualityLevels != 0) {
-                maxMSAASampleCount = sampleCount;
-                break;
-            }
-        }
-
-        D3D12_COMMAND_QUEUE_DESC queue_desc = {
-           /*.Type =*/ D3D12_COMMAND_LIST_TYPE_DIRECT,
-           /*.Priority =*/ D3D12_COMMAND_QUEUE_PRIORITY_NORMAL,
-           /*.Flags =*/ D3D12_COMMAND_QUEUE_FLAG_NONE,
-           /*.NodeMask =*/ 0,
-        };
- 
-        ID3D12CommandQueue *cmdqueue;
-        pdev->CreateCommandQueue(&queue_desc,
-                                 IID_ID3D12CommandQueue,
-                                 (void **)&cmdqueue);
- 
-        uint64_t ts_freq;
-        cmdqueue->GetTimestampFrequency(&ts_freq);
-        timestamp_period = 1000000000.0f / ts_freq;
-        cmdqueue->Release();
-    }
 
     DXCAutoFence::DXCAutoFence()
         : _fence(nullptr)
@@ -377,7 +285,7 @@ namespace alloy::dxc {
         const common::sp<DXCAdapter>& adp,
         const IGraphicsDevice::Options &options
     ) {
-
+        auto& devCaps = adp->GetCaps();
         //Enumeration done. create the selected device
         ComPtr<ID3D12Device> device;
         {
@@ -435,11 +343,6 @@ namespace alloy::dxc {
         dev->_waitIdleFence.Init(std::move(waitIdleFence));
         dev->_alloc = allocator;
 
-        //dev->_adpInfo = {};
-        dev->_dxcFeat = {};
-        dev->_dxcFeat.ReadFromDevice(dev->_dev);
-
-
         D3D12MA::Pool* sysMemUploadPool = nullptr,
                      * sysMemReadbackPool = nullptr,
                      * devLocalPool = nullptr;
@@ -456,12 +359,14 @@ namespace alloy::dxc {
             poolDesc.HeapFlags = D3D12_HEAP_FLAG_CREATE_NOT_ZEROED;
 
             HRESULT hr = allocator->CreatePool(&poolDesc, &sysMemUploadPool);
+            sysMemUploadPool->SetName(L"System upload heap");
             if (FAILED(hr)) {
 
             }
 
             poolDesc.HeapProperties.CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_WRITE_BACK;
             hr = allocator->CreatePool(&poolDesc, &sysMemReadbackPool);
+            sysMemReadbackPool->SetName(L"System readback heap");
             if (FAILED(hr)) {
 
             }
@@ -469,7 +374,7 @@ namespace alloy::dxc {
 
         //Non-UMA device normally has a device local host visible memory
         //Create a heap targeting that
-        if (!dev->_dxcFeat.SupportUMA() && dev->_dxcFeat.SupportReBAR()) {
+        if (!devCaps.SupportUMA() && devCaps.SupportReBAR()) {
             D3D12MA::POOL_DESC poolDesc = {};
             poolDesc.HeapProperties.Type = D3D12_HEAP_TYPE_CUSTOM;
             // For CPU readback use D3D12_CPU_PAGE_PROPERTY_WRITE_BACK
@@ -481,6 +386,7 @@ namespace alloy::dxc {
             poolDesc.HeapFlags = D3D12_HEAP_FLAG_CREATE_NOT_ZEROED;
         
             HRESULT hr = allocator->CreatePool(&poolDesc, &devLocalPool);
+            devLocalPool->SetName(L"Device local visible heap");
             if (FAILED(hr)) {
         
             }
@@ -558,7 +464,7 @@ namespace alloy::dxc {
         dev->_commonFeat.independentBlend = true;
         dev->_commonFeat.structuredBuffer = true;
         dev->_commonFeat.subsetTextureView = true;
-        dev->_commonFeat.shaderFloat64 = dev->_dxcFeat.options.DoublePrecisionFloatShaderOps;   
+        dev->_commonFeat.shaderFloat64 = devCaps.options.DoublePrecisionFloatShaderOps;   
         return dev;
     }
 

--- a/src/backend/dx12/DXCDevice.hpp
+++ b/src/backend/dx12/DXCDevice.hpp
@@ -29,6 +29,7 @@
 //Local headers
 #include "DXCResourceFactory.hpp"
 #include "D3DDescriptorHeapMgr.hpp"
+#include "DXCContext.hpp"
 
 namespace alloy::dxc{
 
@@ -162,48 +163,6 @@ namespace alloy::dxc{
 
     };
 
-    
-    struct D3D12DevCaps{
-        D3D_FEATURE_LEVEL feature_level;
-        D3D_SHADER_MODEL shader_model;
-        D3D_ROOT_SIGNATURE_VERSION root_sig_version;
-        D3D12_FEATURE_DATA_ARCHITECTURE1 architecture;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS options;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS1 options1;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS2 options2;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS3 options3;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS4 options4;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS5 options5;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS7 options7;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS12 options12;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS13 options13;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS14 options14;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS15 options15;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS16 options16;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS17 options17;
-        D3D12_FEATURE_DATA_D3D12_OPTIONS19 options19;
-
-        float timestamp_period;
-        bool support_a4b4g4r4;
-        uint32_t maxMSAASampleCount;
-
-        void ReadFromDevice(ID3D12Device* pdev);
-
-        bool SupportEnhancedBarrier() const { return options12.EnhancedBarriersSupported; }
-        bool SupportMeshShader() const {return options7.MeshShaderTier != D3D12_MESH_SHADER_TIER_NOT_SUPPORTED;}
-        bool SupportReBAR() const { return options16.GPUUploadHeapSupported; }
-        bool SupportUMA() const { return architecture.UMA || architecture.CacheCoherentUMA; }
-    
-        uint32_t ResourceBindingTier() const {
-            switch(options.ResourceBindingTier) {
-                case D3D12_RESOURCE_BINDING_TIER_3: return 3;
-                case D3D12_RESOURCE_BINDING_TIER_2: return 2;
-                case D3D12_RESOURCE_BINDING_TIER_1:
-                default: return 1;
-            }
-        }
-    };
-
     class DXCDevice : public IGraphicsDevice
                     , public DXCResourceFactory
                     , public IDXCTimeline
@@ -237,10 +196,8 @@ namespace alloy::dxc{
         //DXCResourceFactory _resFactory;
 
         //GraphicsApiVersion _apiVer;
-        
 
         IGraphicsDevice::Features _commonFeat;
-        D3D12DevCaps _dxcFeat;
 
         DXCDevice(ID3D12Device* dev);
 
@@ -250,6 +207,8 @@ namespace alloy::dxc{
 
         ID3D12Device* GetDevice() const {return _dev;}
         IPhysicalAdapter& GetAdapter() const override;
+
+        DXCContext& GetContext() const { return _adp->GetContext(); }
 
         virtual void* GetNativeHandle() const override { return GetDevice(); }
 
@@ -287,7 +246,7 @@ namespace alloy::dxc{
         //virtual const IGraphicsDevice::AdapterInfo& GetAdapterInfo() const override { return _adpInfo; }
         virtual const IGraphicsDevice::Features& GetFeatures() const override { return _commonFeat; }
 
-        const D3D12DevCaps& GetDevCaps() const { return _dxcFeat; }
+        const D3D12DevCaps& GetDevCaps() const { return _adp->GetCaps(); }
 
         virtual ResourceFactory& GetResourceFactory() override { return *this; };
 

--- a/src/backend/vk/VkCommon.hpp
+++ b/src/backend/vk/VkCommon.hpp
@@ -43,6 +43,7 @@ struct VkInstExtNames {
     constexpr static const char* VK_EXT_DEBUG_REPORT = "VK_EXT_debug_report";
     constexpr static const char* VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES2 = "VK_KHR_get_physical_device_properties2";
     constexpr static const char* VK_KHR_PORTABILITY_SUBSET = "VK_KHR_portability_subset";
+    constexpr static auto VK_EXT_DEBUG_UTILS = "VK_EXT_debug_utils";
     //static const char* VK_KHR_SWAPCHAIN;
 };
 
@@ -59,7 +60,8 @@ struct VkDevExtNames {
     //static const char* VK_KHR_DYNAMIC_RENDERING;
 
     constexpr static auto VK_KHR_SWAPCHAIN = "VK_KHR_swapchain";
-    constexpr static auto VK_EXT_DEBUG_MARKER = "VK_EXT_debug_marker";
+    //constexpr static auto VK_EXT_DEBUG_MARKER = "VK_EXT_debug_marker";
+
     constexpr static auto VK_KHR_MAINTENANCE1 = "VK_KHR_maintenance1";
     constexpr static auto VK_KHR_GET_MEMORY_REQ2 = "VK_KHR_get_memory_requirements2";
     constexpr static auto VK_KHR_DEDICATED_ALLOCATION = "VK_KHR_dedicated_allocation";

--- a/src/backend/vk/VkSurfaceUtil.cpp
+++ b/src/backend/vk/VkSurfaceUtil.cpp
@@ -1,14 +1,18 @@
 #include "VkSurfaceUtil.hpp"
 
 #include "alloy/common/Macros.h"
+#include "VulkanContext.hpp"
 
 #include <cassert>
 
 
 namespace alloy::VK::priv{
 
-SurfaceContainer CreateSurface(VkInstance instance, alloy::SwapChainSource* swapchainSource) {
+SurfaceContainer CreateSurface(alloy::vk::VulkanContext& ctx, alloy::SwapChainSource* swapchainSource) {
 	assert(swapchainSource != nullptr);
+
+	auto hInst = ctx.GetHandle();
+	auto& fnTable = ctx.GetFnTable();
 
 	switch (swapchainSource->tag) {
 		case alloy::SwapChainSource::Tag::Opaque:{
@@ -24,7 +28,7 @@ SurfaceContainer CreateSurface(VkInstance instance, alloy::SwapChainSource* swap
 			surfaceCI.hwnd = (HWND)win32Source->hWnd;
 			surfaceCI.hinstance = (HINSTANCE)win32Source->hInstance;
 			VkSurfaceKHR surface;
-			VkResult result = vkCreateWin32SurfaceKHR(instance, &surfaceCI, nullptr, &surface);
+			VkResult result = fnTable.vkCreateWin32SurfaceKHR(hInst, &surfaceCI, nullptr, &surface);
 			
 			return {surface, true};
 		}

--- a/src/backend/vk/VkSurfaceUtil.hpp
+++ b/src/backend/vk/VkSurfaceUtil.hpp
@@ -23,13 +23,17 @@
 
 #include <string>
 
+namespace alloy::vk{
+	class VulkanContext;
+}
+
 namespace alloy::VK::priv{
 	struct SurfaceContainer{
 		VkSurfaceKHR surface;
 		bool isOwnSurface;//Is this surface managed by us
 	};
 
-	SurfaceContainer CreateSurface(VkInstance instance, alloy::SwapChainSource* swapchainSource);
+	SurfaceContainer CreateSurface(alloy::vk::VulkanContext& ctx, alloy::SwapChainSource* swapchainSource);
 
 	std::string GetSurfaceExtension(alloy::SwapChainSource* swapchainSource);
 }

--- a/src/backend/vk/VulkanBindableResource.cpp
+++ b/src/backend/vk/VulkanBindableResource.cpp
@@ -282,8 +282,8 @@ namespace alloy::vk
                                 auto* range = PtrCast<BufferRange>(pElemRes);
                                 auto* rangedVkBuffer = static_cast<const VulkanBuffer*>(range->GetBufferObject());
                                 bufferInfos[i].buffer = rangedVkBuffer->GetHandle();
-                                bufferInfos[i].offset = range->GetShape().offsetInElements;
-                                bufferInfos[i].range = range->GetShape().elementCount;
+                                bufferInfos[i].offset = range->GetShape().GetOffsetInBytes();
+                                bufferInfos[i].range = range->GetShape().GetSizeInBytes();
                                 //_refCounts.push_back(boundResources[i]);
                             } break;
 

--- a/src/backend/vk/VulkanCommandList.cpp
+++ b/src/backend/vk/VulkanCommandList.cpp
@@ -7,6 +7,7 @@
 #include "VkTypeCvt.hpp"
 #include "VulkanDevice.hpp"
 #include "VulkanTexture.hpp"
+#include "VulkanContext.hpp"
 //#include "VulkanResourceBarrier.hpp"
 
 #include <ranges>
@@ -157,6 +158,55 @@ namespace alloy::vk{
             }
         }
     }
+    
+    void VkCmdEncBase::PushDebugGroup(const std::string& name, const Color4f& color) {
+        if(!dev->GetContext().GetCaps().hasDebugUtilExt) return;
+
+        recordedCmds.emplace_back([this, name, color](VkCommandBuffer cmdList){
+            VkDebugUtilsLabelEXT markerInfo = {};
+            markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+            markerInfo.pLabelName = name.c_str();
+            markerInfo.color[0] = color.r;
+            markerInfo.color[1] = color.g;
+            markerInfo.color[2] = color.b;
+            markerInfo.color[3] = color.a;
+
+            VK_INST_CALL(dev, vkCmdBeginDebugUtilsLabelEXT(
+                cmdList, 
+                &markerInfo));
+
+        });
+    }
+
+    void VkCmdEncBase::PopDebugGroup() {
+        if(!dev->GetContext().GetCaps().hasDebugUtilExt) return;
+
+        recordedCmds.emplace_back([this](VkCommandBuffer cmdList){
+            VK_INST_CALL(dev, vkCmdEndDebugUtilsLabelEXT(cmdList));
+
+        });
+
+    }
+
+    void VkCmdEncBase::InsertDebugMarker(const std::string& name, const Color4f& color) {
+        if(!dev->GetContext().GetCaps().hasDebugUtilExt) return;
+
+        recordedCmds.emplace_back([this, name, color](VkCommandBuffer cmdList){
+            VkDebugUtilsLabelEXT markerInfo = {};
+            markerInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT;
+            markerInfo.pLabelName = name.c_str();
+            markerInfo.color[0] = color.r;
+            markerInfo.color[1] = color.g;
+            markerInfo.color[2] = color.b;
+            markerInfo.color[3] = color.a;
+
+            VK_INST_CALL(dev, vkCmdInsertDebugUtilsLabelEXT(
+                cmdList, 
+                &markerInfo));
+
+        });
+    }
+    
 #if 0
     void _DevResRegistry::ModifyTexUsage(
         const sp<Texture>& tex,
@@ -305,11 +355,28 @@ namespace alloy::vk{
 
     }
     void VulkanCommandList::End(){
-        if(_currentPass != nullptr) {
-            assert(false);
-        }
+        //if(_currentPass != nullptr) {
+        //    assert(false);
+        //}
+        _EndCurrentActivePass();
 
         VK_DEV_CALL(_dev, vkEndCommandBuffer(_cmdBuf));
+    }
+
+    void VulkanCommandList::_EndCurrentActivePass() {
+        if(_currentPass) {
+            EndPass();
+        }
+    }
+
+    void VulkanCommandList::_BeginDummyPassIfNoActivePass() {
+        if(!_currentPass) {
+            //Begin a dummy pass for misc command recording
+            auto dummyPass = new VkCmdEncBase(_dev.get(), _cmdBuf);
+            //auto* pNewEnc = new _DXCDummyPass(_dev.get(), this);
+            _passes.push_back(dummyPass);
+            _currentPass = dummyPass;
+        }
     }
 
     void VkRenderCmdEnc::SetPipeline(const common::sp<IGfxPipeline>& pipeline){
@@ -1309,11 +1376,20 @@ namespace alloy::vk{
 #endif
     }
 
-    void VulkanCommandList::PushDebugGroup(const std::string& name, const Color4f&) {};
+    void VulkanCommandList::PushDebugGroup(const std::string& name, const Color4f& color) {
+        _BeginDummyPassIfNoActivePass();
+        _currentPass->PushDebugGroup(name, color);
+    };
 
-    void VulkanCommandList::PopDebugGroup() {};
+    void VulkanCommandList::PopDebugGroup() {
+        _BeginDummyPassIfNoActivePass();
+        _currentPass->PopDebugGroup();
+    };
 
-    void VulkanCommandList::InsertDebugMarker(const std::string& name, const Color4f&) {};
+    void VulkanCommandList::InsertDebugMarker(const std::string& name, const Color4f& color) {
+        _BeginDummyPassIfNoActivePass();
+        _currentPass->InsertDebugMarker(name, color);
+    };
 
     
     void VulkanCommandList::Barrier(const std::vector<alloy::BarrierDescription>& barriers) {
@@ -1338,6 +1414,9 @@ namespace alloy::vk{
     void VulkanCommandList::TransitionTextureToDefaultLayout(
         const std::vector<common::sp<ITexture>>& textures
     ) {
+        //#TODO: revisit this function once we have unified auto state tracking
+        // between dx12 & vulkan
+        assert(false);
         CHK_RENDERPASS_ENDED();
         
         auto* dummyPass = new VkCmdEncBase(_dev.get(), _cmdBuf);
@@ -1376,7 +1455,7 @@ namespace alloy::vk{
             
             VulkanCommandList::TextureState state{};
             state.access = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-            if(ctAct.loadAction == LoadAction::Load)
+            if(ctAct.loadAction != alloy::LoadAction::DontCare)
                 state.access |= VK_ACCESS_COLOR_ATTACHMENT_READ_BIT;
             state.stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
             state.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -1403,15 +1482,14 @@ namespace alloy::vk{
             state.stage = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT 
                         | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
 
-            if(fb.depthTargetAction->storeAction != alloy::StoreAction::DontCare)
-            {
-                state.access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT
-                             | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
-                state.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-            } else {
-                state.access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
-                state.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
+            //Always writable
+            state.access = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
+            if(fb.depthTargetAction->loadAction != alloy::LoadAction::DontCare) {
+                //Either clear or load means content is readable
+                state.access |= VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT;
             }
+
+            state.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
             RegisterTexUsage(vkDepthTex, state);
 
             if(fb.depthTargetAction->msaaResolveTarget) {
@@ -1630,7 +1708,8 @@ namespace alloy::vk{
     }
 
     IRenderCommandEncoder& VulkanCommandList::BeginRenderPass(const RenderPassAction& actions) {
-        CHK_RENDERPASS_ENDED();
+        //CHK_RENDERPASS_ENDED();
+        _EndCurrentActivePass();
         
         //auto vkfb = common::SPCast<VulkanFrameBufferBase>(fb);
         
@@ -1647,7 +1726,8 @@ namespace alloy::vk{
     }
     
     IComputeCommandEncoder& VulkanCommandList::BeginComputePass() {
-        CHK_RENDERPASS_ENDED();
+        //CHK_RENDERPASS_ENDED();
+        _EndCurrentActivePass();
         
         auto* pNewEnc = new VkComputeCmdEnc(_dev.get(), _cmdBuf);
         //Record render pass
@@ -1659,7 +1739,8 @@ namespace alloy::vk{
     }
     
     ITransferCommandEncoder& VulkanCommandList::BeginTransferPass() {
-        CHK_RENDERPASS_ENDED();
+        //CHK_RENDERPASS_ENDED();
+        _EndCurrentActivePass();
         
         auto* pNewEnc = new VkTransferCmdEnc(_dev.get(), _cmdBuf);
         //Record render pass

--- a/src/backend/vk/VulkanCommandList.hpp
+++ b/src/backend/vk/VulkanCommandList.hpp
@@ -82,6 +82,8 @@ namespace alloy::vk
         //std::set<sp<VulkanFramebuffer>> _currRenderPassFBs;
         ResourceStates _requestedStates, _finalStates;
 
+        void _EndCurrentActivePass();
+        void _BeginDummyPassIfNoActivePass();
 
     public:
         VulkanCommandList(
@@ -230,6 +232,10 @@ namespace alloy::vk
         );
 
         void RegisterResourceSet(VulkanResourceSet* rs);
+        
+        void PushDebugGroup(const std::string& name, const Color4f&);
+        void PopDebugGroup();
+        void InsertDebugMarker(const std::string& name, const Color4f&);
 
     };
 

--- a/src/backend/vk/VulkanContext.cpp
+++ b/src/backend/vk/VulkanContext.cpp
@@ -1,6 +1,8 @@
 #include "VulkanContext.hpp"
 
 #include "VulkanDevice.hpp"
+#include <unordered_set>
+#include <string>
 
 namespace alloy
 {
@@ -14,13 +16,141 @@ namespace alloy
 
 namespace alloy::vk
 {
+    void VulkanDevCaps::ReadFromDevice(VulkanContext& ctx, VkPhysicalDevice adp) {
+        *this = { };
+
+        auto& fnTable = ctx.GetFnTable();
+        
+        VkPhysicalDeviceProperties devProps { };
+        fnTable.vkGetPhysicalDeviceProperties(adp, &devProps);
+
+        apiVersion = {Backend::Vulkan, VK_API_VERSION_MAJOR(devProps.apiVersion)
+                                     , VK_API_VERSION_MINOR(devProps.apiVersion)
+                                     , 0
+                                     , VK_API_VERSION_PATCH(devProps.apiVersion)};
+
+        limits = devProps.limits;
+        sparseProperties = devProps.sparseProperties;
+
+        isIntegratedGPU 
+            = devProps.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
+
+        fnTable.vkGetPhysicalDeviceFeatures(adp, &features);
+
+        if(devProps.apiVersion >= VK_VERSION_1_1) {
+
+            VkPhysicalDeviceProperties2 devProps2 { 
+                .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2
+            };
+
+            VkPhysicalDeviceFeatures2 features2 { 
+                .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2
+            };
+
+            properties11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES;
+            devProps2.pNext = &properties11;
+
+            features11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
+            features2.pNext = &features11;
+
+            if(devProps.apiVersion >= VK_API_VERSION_1_2) {
+                properties12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES;
+                properties12.pNext = devProps2.pNext;
+                devProps2.pNext = &properties12;
+
+                features12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
+                features12.pNext = features2.pNext;
+                features2.pNext = &features12;
+            }
+
+            if(devProps.apiVersion >= VK_API_VERSION_1_3) {
+                properties13.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES;
+                properties13.pNext = devProps2.pNext;
+                devProps2.pNext = &properties13;
+
+                features13.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES;
+                features13.pNext = features2.pNext;
+                features2.pNext = &features13;
+            }
+
+            if(devProps.apiVersion >= VK_API_VERSION_1_4) {
+                properties14.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_PROPERTIES;
+                properties14.pNext = devProps2.pNext;
+                devProps2.pNext = &properties14;
+
+                features14.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_4_FEATURES;
+                features14.pNext = features2.pNext;
+                features2.pNext = &features14;
+            }
+
+            fnTable.vkGetPhysicalDeviceProperties2(adp, &devProps2);
+            fnTable.vkGetPhysicalDeviceFeatures2(adp, &features2);
+        }
+
+        //Resizable BAR system will have a >256MB HOST_VISIBLE DEVICE_LOCAL heap
+        VkPhysicalDeviceMemoryProperties vramProp{};
+        fnTable.vkGetPhysicalDeviceMemoryProperties(adp, &vramProp);
+        constexpr auto BARPropBits = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | 
+                                    VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+
+        constexpr size_t defaultBARSize = 256 * 1024 * 1024; //256MB
+
+        for(uint32_t i = 0; i < vramProp.memoryTypeCount; i++) {
+            auto& type = vramProp.memoryTypes[i];
+
+            auto isBARType = type.propertyFlags & BARPropBits == BARPropBits;
+            if(isBARType) {
+                auto& heap = vramProp.memoryHeaps[type.heapIndex];
+                if(heap.size > defaultBARSize) {
+                    isResizableBARSupported = true;
+                    break;
+                }
+            }
+        }
+
+        //Get all supported extensions
+        uint32_t extensionCount;
+        fnTable.vkEnumerateDeviceExtensionProperties(adp, nullptr, &extensionCount, nullptr);
+        std::vector<VkExtensionProperties> availableExtensions(extensionCount);
+        fnTable.vkEnumerateDeviceExtensionProperties(adp, nullptr, &extensionCount, availableExtensions.data());
+
+        std::unordered_set<std::string> availableExtNames;
+        for(auto& ext : availableExtensions) {
+            availableExtNames.emplace(ext.extensionName);
+        }
+
+        auto IsExtSupported = [&](const std::string& extName) {
+            return availableExtNames.contains(extName);
+        };
+
+        if( devProps.apiVersion >= VK_VERSION_1_4 || 
+            IsExtSupported(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME)
+        ) {
+            features12.scalarBlockLayout = true;
+        }
+
+        if(IsExtSupported(VK_EXT_MESH_SHADER_EXTENSION_NAME)) {
+            supportMeshShader = true;
+        }
+
+        if( IsExtSupported(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME) &&
+            IsExtSupported(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME) &&
+            IsExtSupported(VK_KHR_RAY_QUERY_EXTENSION_NAME)
+        ) {
+            supportRayTracing = true;
+        }
+
+        if(IsExtSupported(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)) {
+            supportBindless = true;
+        }
+    }
+
+
+
+
     uint32_t VulkanContext::VolkCtx::_refCnt = 0;
     std::mutex VulkanContext::VolkCtx::_m;
-    VulkanContext::Features VulkanContext::VolkCtx::_features {};
-    VkDebugReportCallbackEXT VulkanContext::VolkCtx::_debugCallbackHandle = VK_NULL_HANDLE;
 
-
-    
     common::sp<IGraphicsDevice> VulkanContext::CreateDefaultDevice(
         const IGraphicsDevice::Options& options
     ) {
@@ -38,12 +168,13 @@ namespace alloy::vk
         const common::sp<VulkanContext>& ctx,
         VkPhysicalDevice handle
     ) {
+        auto& fnTable = ctx->GetFnTable();
 
         //Find graphics queue
         std::uint32_t queueFamCnt;
-        vkGetPhysicalDeviceQueueFamilyProperties(handle, &queueFamCnt, nullptr);
+        fnTable.vkGetPhysicalDeviceQueueFamilyProperties(handle, &queueFamCnt, nullptr);
         std::vector<VkQueueFamilyProperties> queue_family_properties(queueFamCnt);
-        vkGetPhysicalDeviceQueueFamilyProperties(handle, &queueFamCnt, queue_family_properties.data());
+        fnTable.vkGetPhysicalDeviceQueueFamilyProperties(handle, &queueFamCnt, queue_family_properties.data());
 
         if (queue_family_properties.empty())
         {
@@ -105,18 +236,15 @@ namespace alloy::vk
         adp->_qFamily.graphicsQueueFamily = graphicsQueueFamily;
 
         VkPhysicalDeviceProperties devProp{};
-        vkGetPhysicalDeviceProperties(handle, &devProp);
+        fnTable.vkGetPhysicalDeviceProperties(handle, &devProp);
+
         adp->info.deviceName = devProp.deviceName;
-
-        adp->info.apiVersion = {Backend::Vulkan, VK_API_VERSION_MAJOR(devProp.apiVersion)
-                                               , VK_API_VERSION_MINOR(devProp.apiVersion)
-                                               , 0
-                                               , VK_API_VERSION_PATCH(devProp.apiVersion)};
-
         adp->info.driverVersion = devProp.driverVersion;
         adp->info.vendorID = devProp.vendorID;
         adp->info.deviceID = devProp.deviceID;
 
+        adp->PopulateAdpFeatures();
+        adp->info.apiVersion = adp->_caps.apiVersion;
         adp->PopulateAdpMemSegs();
         adp->PopulateAdpLimits();
 
@@ -128,21 +256,13 @@ namespace alloy::vk
             }
         }
         
-        if (devProp.deviceType == VkPhysicalDeviceType::VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU) {
+        if (adp->_caps.isIntegratedGPU) {
             ///#TODO: Default all integrated GPUs to UMA 
             adp->info.capabilities.isUMA = true;
-        } else {
-            ////Find if resizable bar is enabled
-            //uint64_t hostVisibleVramSize = 0;
-            //for(auto& seg : adp->info.memSegments) {
-            //    if(seg.flags.isCPUVisible && !seg.flags.isInSysMem) {
-            //        hostVisibleVramSize += seg.sizeInBytes;
-            //    }
-            //}
-            //
-            //if(hostVisibleVramSize > 256 * 1024 * 1024) {
-            //    adp->info.capabilities.supportReBar = 1;
-            //}
+        } 
+
+        if(adp->_caps.isResizableBARSupported) {
+            adp->info.capabilities.supportResizableBar = 1;
         }
 
         {
@@ -169,9 +289,7 @@ namespace alloy::vk
     }
     
     void VulkanAdapter::PopulateAdpLimits() {
-        
-        VkPhysicalDeviceProperties devProp{};
-        vkGetPhysicalDeviceProperties(_handle, &devProp);
+        auto& fnTable = _ctx->GetFnTable();
 
         auto _VkSampleCnts2AlSampleCnt = [](VkSampleCountFlags flags) {
             if(flags & VK_SAMPLE_COUNT_64_BIT) return SampleCount::x32;
@@ -183,101 +301,109 @@ namespace alloy::vk
             return  SampleCount::x1;
         };
 
-        info.limits.maxImageDimension1D = devProp.limits.maxImageDimension1D; 
-        info.limits.maxImageDimension2D = devProp.limits.maxImageDimension2D; 
-        info.limits.maxImageDimension3D = devProp.limits.maxImageDimension3D; 
-        info.limits.maxImageDimensionCube = devProp.limits.maxImageDimensionCube; 
-        info.limits.maxImageArrayLayers = devProp.limits.maxImageArrayLayers; 
-        info.limits.maxTexelBufferElements = devProp.limits.maxTexelBufferElements; 
-        info.limits.maxUniformBufferRange = devProp.limits.maxUniformBufferRange; 
-        info.limits.maxStorageBufferRange = devProp.limits.maxStorageBufferRange; 
-        info.limits.maxPushConstantsSize = devProp.limits.maxPushConstantsSize; 
-        info.limits.maxMemoryAllocationCount = devProp.limits.maxMemoryAllocationCount; 
-        info.limits.maxSamplerAllocationCount = devProp.limits.maxSamplerAllocationCount; 
-        info.limits.bufferImageGranularity = devProp.limits.bufferImageGranularity; 
-        info.limits.sparseAddressSpaceSize = devProp.limits.sparseAddressSpaceSize; 
-        info.limits.maxBoundDescriptorSets = devProp.limits.maxBoundDescriptorSets; 
-        info.limits.maxPerStageDescriptorSamplers = devProp.limits.maxPerStageDescriptorSamplers; 
-        info.limits.maxPerStageDescriptorUniformBuffers = devProp.limits.maxPerStageDescriptorUniformBuffers; 
-        info.limits.maxPerStageDescriptorStorageBuffers = devProp.limits.maxPerStageDescriptorStorageBuffers; 
-        info.limits.maxPerStageDescriptorSampledImages = devProp.limits.maxPerStageDescriptorSampledImages; 
-        info.limits.maxPerStageDescriptorStorageImages = devProp.limits.maxPerStageDescriptorStorageImages; 
-        info.limits.maxPerStageDescriptorInputAttachments = devProp.limits.maxPerStageDescriptorInputAttachments; 
-        info.limits.maxPerStageResources = devProp.limits.maxPerStageResources; 
-        info.limits.maxVertexInputAttributes = devProp.limits.maxVertexInputAttributes; 
-        info.limits.maxVertexInputBindings = devProp.limits.maxVertexInputBindings; 
-        info.limits.maxVertexInputAttributeOffset = devProp.limits.maxVertexInputAttributeOffset; 
-        info.limits.maxVertexInputBindingStride = devProp.limits.maxVertexInputBindingStride; 
-        info.limits.maxVertexOutputComponents = devProp.limits.maxVertexOutputComponents; 
-        info.limits.maxFragmentInputComponents = devProp.limits.maxFragmentInputComponents; 
-        info.limits.maxFragmentOutputAttachments = devProp.limits.maxFragmentOutputAttachments; 
-        info.limits.maxFragmentDualSrcAttachments = devProp.limits.maxFragmentDualSrcAttachments; 
-        info.limits.maxFragmentCombinedOutputResources = devProp.limits.maxFragmentCombinedOutputResources; 
-        info.limits.maxComputeSharedMemorySize = devProp.limits.maxComputeSharedMemorySize; 
-        info.limits.maxComputeWorkGroupCount[0] = devProp.limits.maxComputeWorkGroupCount[0]; 
-        info.limits.maxComputeWorkGroupCount[1] = devProp.limits.maxComputeWorkGroupCount[1]; 
-        info.limits.maxComputeWorkGroupCount[2] = devProp.limits.maxComputeWorkGroupCount[2]; 
-        info.limits.maxComputeWorkGroupInvocations = devProp.limits.maxComputeWorkGroupInvocations; 
-        info.limits.maxComputeWorkGroupSize[0] = devProp.limits.maxComputeWorkGroupSize[0]; 
-        info.limits.maxComputeWorkGroupSize[1] = devProp.limits.maxComputeWorkGroupSize[1]; 
-        info.limits.maxComputeWorkGroupSize[2] = devProp.limits.maxComputeWorkGroupSize[2]; 
-        info.limits.maxDrawIndexedIndexValue = devProp.limits.maxDrawIndexedIndexValue; 
-        info.limits.maxDrawIndirectCount = devProp.limits.maxDrawIndirectCount; 
-        info.limits.maxSamplerLodBias = devProp.limits.maxSamplerLodBias; 
-        info.limits.maxSamplerAnisotropy = devProp.limits.maxSamplerAnisotropy; 
-        info.limits.maxViewports = devProp.limits.maxViewports; 
-        info.limits.maxViewportDimensions[0] = devProp.limits.maxViewportDimensions[0];
-        info.limits.maxViewportDimensions[1] = devProp.limits.maxViewportDimensions[1];
-        info.limits.minMemoryMapAlignment = devProp.limits.minMemoryMapAlignment; 
-        info.limits.minTexelBufferOffsetAlignment = devProp.limits.minTexelBufferOffsetAlignment; 
-        info.limits.minUniformBufferOffsetAlignment = devProp.limits.minUniformBufferOffsetAlignment; 
-        info.limits.minStorageBufferOffsetAlignment = devProp.limits.minStorageBufferOffsetAlignment; 
-        info.limits.maxFramebufferWidth = devProp.limits.maxFramebufferWidth; 
-        info.limits.maxFramebufferHeight = devProp.limits.maxFramebufferHeight; 
-        info.limits.maxFramebufferLayers = devProp.limits.maxFramebufferLayers; 
+        info.limits.maxImageDimension1D = _caps.limits.maxImageDimension1D; 
+        info.limits.maxImageDimension2D = _caps.limits.maxImageDimension2D; 
+        info.limits.maxImageDimension3D = _caps.limits.maxImageDimension3D; 
+        info.limits.maxImageDimensionCube = _caps.limits.maxImageDimensionCube; 
+        info.limits.maxImageArrayLayers = _caps.limits.maxImageArrayLayers; 
+        info.limits.maxTexelBufferElements = _caps.limits.maxTexelBufferElements; 
+        info.limits.maxUniformBufferRange = _caps.limits.maxUniformBufferRange; 
+        info.limits.maxStorageBufferRange = _caps.limits.maxStorageBufferRange; 
+        info.limits.maxPushConstantsSize = _caps.limits.maxPushConstantsSize; 
+        info.limits.maxMemoryAllocationCount = _caps.limits.maxMemoryAllocationCount; 
+        info.limits.maxSamplerAllocationCount = _caps.limits.maxSamplerAllocationCount; 
+        info.limits.bufferImageGranularity = _caps.limits.bufferImageGranularity; 
+        info.limits.sparseAddressSpaceSize = _caps.limits.sparseAddressSpaceSize; 
+        info.limits.maxBoundDescriptorSets = _caps.limits.maxBoundDescriptorSets; 
+        info.limits.maxPerStageDescriptorSamplers = _caps.limits.maxPerStageDescriptorSamplers; 
+        info.limits.maxPerStageDescriptorUniformBuffers = _caps.limits.maxPerStageDescriptorUniformBuffers; 
+        info.limits.maxPerStageDescriptorStorageBuffers = _caps.limits.maxPerStageDescriptorStorageBuffers; 
+        info.limits.maxPerStageDescriptorSampledImages = _caps.limits.maxPerStageDescriptorSampledImages; 
+        info.limits.maxPerStageDescriptorStorageImages = _caps.limits.maxPerStageDescriptorStorageImages; 
+        info.limits.maxPerStageDescriptorInputAttachments = _caps.limits.maxPerStageDescriptorInputAttachments; 
+        info.limits.maxPerStageResources = _caps.limits.maxPerStageResources; 
+        info.limits.maxVertexInputAttributes = _caps.limits.maxVertexInputAttributes; 
+        info.limits.maxVertexInputBindings = _caps.limits.maxVertexInputBindings; 
+        info.limits.maxVertexInputAttributeOffset = _caps.limits.maxVertexInputAttributeOffset; 
+        info.limits.maxVertexInputBindingStride = _caps.limits.maxVertexInputBindingStride; 
+        info.limits.maxVertexOutputComponents = _caps.limits.maxVertexOutputComponents; 
+        info.limits.maxFragmentInputComponents = _caps.limits.maxFragmentInputComponents; 
+        info.limits.maxFragmentOutputAttachments = _caps.limits.maxFragmentOutputAttachments; 
+        info.limits.maxFragmentDualSrcAttachments = _caps.limits.maxFragmentDualSrcAttachments; 
+        info.limits.maxFragmentCombinedOutputResources = _caps.limits.maxFragmentCombinedOutputResources; 
+        info.limits.maxComputeSharedMemorySize = _caps.limits.maxComputeSharedMemorySize; 
+        info.limits.maxComputeWorkGroupCount[0] = _caps.limits.maxComputeWorkGroupCount[0]; 
+        info.limits.maxComputeWorkGroupCount[1] = _caps.limits.maxComputeWorkGroupCount[1]; 
+        info.limits.maxComputeWorkGroupCount[2] = _caps.limits.maxComputeWorkGroupCount[2]; 
+        info.limits.maxComputeWorkGroupInvocations = _caps.limits.maxComputeWorkGroupInvocations; 
+        info.limits.maxComputeWorkGroupSize[0] = _caps.limits.maxComputeWorkGroupSize[0]; 
+        info.limits.maxComputeWorkGroupSize[1] = _caps.limits.maxComputeWorkGroupSize[1]; 
+        info.limits.maxComputeWorkGroupSize[2] = _caps.limits.maxComputeWorkGroupSize[2]; 
+        info.limits.maxDrawIndexedIndexValue = _caps.limits.maxDrawIndexedIndexValue; 
+        info.limits.maxDrawIndirectCount = _caps.limits.maxDrawIndirectCount; 
+        info.limits.maxSamplerLodBias = _caps.limits.maxSamplerLodBias; 
+        info.limits.maxSamplerAnisotropy = _caps.limits.maxSamplerAnisotropy; 
+        info.limits.maxViewports = _caps.limits.maxViewports; 
+        info.limits.maxViewportDimensions[0] = _caps.limits.maxViewportDimensions[0];
+        info.limits.maxViewportDimensions[1] = _caps.limits.maxViewportDimensions[1];
+        info.limits.minMemoryMapAlignment = _caps.limits.minMemoryMapAlignment; 
+        info.limits.minTexelBufferOffsetAlignment = _caps.limits.minTexelBufferOffsetAlignment; 
+        info.limits.minUniformBufferOffsetAlignment = _caps.limits.minUniformBufferOffsetAlignment; 
+        info.limits.minStorageBufferOffsetAlignment = _caps.limits.minStorageBufferOffsetAlignment; 
+        info.limits.maxFramebufferWidth = _caps.limits.maxFramebufferWidth; 
+        info.limits.maxFramebufferHeight = _caps.limits.maxFramebufferHeight; 
+        info.limits.maxFramebufferLayers = _caps.limits.maxFramebufferLayers; 
         //info.limits.framebufferColorSampleCounts 
-        //    = _VkSampleCnts2AlSampleCnt(devProp.limits.framebufferColorSampleCounts); 
+        //    = _VkSampleCnts2AlSampleCnt(_caps.limits.framebufferColorSampleCounts); 
         //info.limits.framebufferDepthSampleCounts 
-        //    = _VkSampleCnts2AlSampleCnt(devProp.limits.framebufferDepthSampleCounts); 
+        //    = _VkSampleCnts2AlSampleCnt(_caps.limits.framebufferDepthSampleCounts); 
         //info.limits.framebufferStencilSampleCounts 
-        //    = _VkSampleCnts2AlSampleCnt(devProp.limits.framebufferStencilSampleCounts); 
+        //    = _VkSampleCnts2AlSampleCnt(_caps.limits.framebufferStencilSampleCounts); 
         //info.limits.framebufferNoAttachmentsSampleCounts 
-        //    = _VkSampleCnts2AlSampleCnt(devProp.limits.framebufferNoAttachmentsSampleCounts); 
-        info.limits.maxColorAttachments = devProp.limits.maxColorAttachments; 
+        //    = _VkSampleCnts2AlSampleCnt(_caps.limits.framebufferNoAttachmentsSampleCounts); 
+        info.limits.maxColorAttachments = _caps.limits.maxColorAttachments; 
         //info.limits.sampledImageColorSampleCounts 
-        //    = _VkSampleCnts2AlSampleCnt(devProp.limits.sampledImageColorSampleCounts); 
+        //    = _VkSampleCnts2AlSampleCnt(_caps.limits.sampledImageColorSampleCounts); 
         //info.limits.sampledImageIntegerSampleCounts 
-        //    = _VkSampleCnts2AlSampleCnt(devProp.limits.sampledImageIntegerSampleCounts); 
+        //    = _VkSampleCnts2AlSampleCnt(_caps.limits.sampledImageIntegerSampleCounts); 
         //info.limits.sampledImageDepthSampleCounts 
-        //    = _VkSampleCnts2AlSampleCnt(devProp.limits.sampledImageDepthSampleCounts); 
+        //    = _VkSampleCnts2AlSampleCnt(_caps.limits.sampledImageDepthSampleCounts); 
         //info.limits.sampledImageStencilSampleCounts 
-        //    = _VkSampleCnts2AlSampleCnt(devProp.limits.sampledImageStencilSampleCounts); 
+        //    = _VkSampleCnts2AlSampleCnt(_caps.limits.sampledImageStencilSampleCounts); 
         //info.limits.storageImageSampleCounts 
-        //    = _VkSampleCnts2AlSampleCnt(devProp.limits.storageImageSampleCounts); 
-        //info.limits.maxSampleMaskWords = devProp.limits.maxSampleMaskWords; 
-        info.limits.timestampPeriod = devProp.limits.timestampPeriod; 
-        info.limits.maxClipDistances = devProp.limits.maxClipDistances; 
-        info.limits.maxCullDistances = devProp.limits.maxCullDistances; 
-        info.limits.maxCombinedClipAndCullDistances = devProp.limits.maxCombinedClipAndCullDistances; 
-        //info.limits.pointSizeRange[0] = devProp.limits.pointSizeRange[0]; 
-        //info.limits.pointSizeRange[1] = devProp.limits.pointSizeRange[1]; 
-        //info.limits.lineWidthRange[0] = devProp.limits.lineWidthRange[0]; 
-        //info.limits.lineWidthRange[1] = devProp.limits.lineWidthRange[1]; 
-        info.limits.pointSizeGranularity = devProp.limits.pointSizeGranularity; 
-        info.limits.lineWidthGranularity = devProp.limits.lineWidthGranularity;
+        //    = _VkSampleCnts2AlSampleCnt(_caps.limits.storageImageSampleCounts); 
+        //info.limits.maxSampleMaskWords = _caps.limits.maxSampleMaskWords; 
+        info.limits.timestampPeriod = _caps.limits.timestampPeriod; 
+        info.limits.maxClipDistances = _caps.limits.maxClipDistances; 
+        info.limits.maxCullDistances = _caps.limits.maxCullDistances; 
+        info.limits.maxCombinedClipAndCullDistances = _caps.limits.maxCombinedClipAndCullDistances; 
+        //info.limits.pointSizeRange[0] = _caps.limits.pointSizeRange[0]; 
+        //info.limits.pointSizeRange[1] = _caps.limits.pointSizeRange[1]; 
+        //info.limits.lineWidthRange[0] = _caps.limits.lineWidthRange[0]; 
+        //info.limits.lineWidthRange[1] = _caps.limits.lineWidthRange[1]; 
+        info.limits.pointSizeGranularity = _caps.limits.pointSizeGranularity; 
+        info.limits.lineWidthGranularity = _caps.limits.lineWidthGranularity;
 
-        auto generalMSAASampleCntBits = devProp.limits.framebufferColorSampleCounts   //Render target supported
-                                      & devProp.limits.sampledImageColorSampleCounts  //Sampled support
-                                      & devProp.limits.storageImageSampleCounts       //Storage support
+        auto generalMSAASampleCntBits = _caps.limits.framebufferColorSampleCounts   //Render target supported
+                                      & _caps.limits.sampledImageColorSampleCounts  //Sampled support
+                                      & _caps.limits.storageImageSampleCounts       //Storage support
                                       ;
         info.limits.maxMSAASampleCount = _VkSampleCnts2AlSampleCnt(generalMSAASampleCntBits);
+        
+        //Will update in PopulateAdpFeatures
+        info.limits.minStructuredBufferStride = _caps.SupportScalarBlockLayout() ? 4 : 16;
+    }
+
+    void VulkanAdapter::PopulateAdpFeatures() {
+        _caps.ReadFromDevice(*_ctx, _handle);
     }
 
     void VulkanAdapter::PopulateAdpMemSegs() {
+        auto& fnTable = _ctx->GetFnTable();
         info.memSegments.clear();
         //Evaluate vram size
         VkPhysicalDeviceMemoryProperties vramProp{};
-        vkGetPhysicalDeviceMemoryProperties(_handle, &vramProp);
+        fnTable.vkGetPhysicalDeviceMemoryProperties(_handle, &vramProp);
 
         auto _IsHeapSatisfied = [&](
             uint32_t heapIdx,
@@ -380,10 +506,11 @@ namespace alloy::vk
 
     std::vector<common::sp<IPhysicalAdapter>> VulkanContext::EnumerateAdapters() {
 
-        const static std::vector<std::string> requiredExtensions = {
+        const static std::unordered_set<std::string> requiredExtensions = {
             VkDevExtNames::VK_KHR_SYNCHRONIZATION2,
             VkDevExtNames::VK_KHR_TIMELINE_SEMAPHORE,
             VkDevExtNames::VK_KHR_DYNAMIC_RENDERING,
+            VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME,
             VkDevExtNames::VK_KHR_DEPTH_STENCIL_RESOLVE,
             VkDevExtNames::VK_KHR_CREATE_RENDERPASS2,
             VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME,
@@ -393,23 +520,25 @@ namespace alloy::vk
         auto _IsAdpSupportRequiredExts = [&](VkPhysicalDevice adp)->bool {
             //Does device supports required extensions
             uint32_t extensionCount;
-            vkEnumerateDeviceExtensionProperties(adp, nullptr, &extensionCount, nullptr);
+            _fnTable.vkEnumerateDeviceExtensionProperties(adp, nullptr, &extensionCount, nullptr);
             std::vector<VkExtensionProperties> availableExtensions(extensionCount);
-            vkEnumerateDeviceExtensionProperties(adp, nullptr, &extensionCount, availableExtensions.data());
+            _fnTable.vkEnumerateDeviceExtensionProperties(adp, nullptr, &extensionCount, availableExtensions.data());
 
-            std::unordered_set<std::string> reqExtSet(requiredExtensions.begin(), requiredExtensions.end());
-
+            uint32_t reqExtFoundCount = 0;
+            
             for (const auto& extension : availableExtensions) {
-                reqExtSet.erase(extension.extensionName);
+                if(requiredExtensions.contains(extension.extensionName)) {
+                    reqExtFoundCount++;
+                }
             }
 
-            return reqExtSet.empty();
+            return reqExtFoundCount == requiredExtensions.size();
         };
 
         std::uint32_t devCnt;
-        VK_CHECK(vkEnumeratePhysicalDevices(_instance, &devCnt, nullptr));
+        VK_CHECK(_fnTable.vkEnumeratePhysicalDevices(_instance, &devCnt, nullptr));
         std::vector<VkPhysicalDevice> gpus(devCnt);
-        VK_CHECK(vkEnumeratePhysicalDevices(_instance, &devCnt, gpus.data()));
+        VK_CHECK(_fnTable.vkEnumeratePhysicalDevices(_instance, &devCnt, gpus.data()));
 
         std::vector<common::sp<IPhysicalAdapter>> adapters;
         
@@ -424,6 +553,162 @@ namespace alloy::vk
         };
 
         return adapters;
+    }
+
+    common::sp<VulkanContext> VulkanContext::Make(const IContext::Options& opts) {
+
+        if(!VolkCtx::Ref()) {
+            return nullptr;
+        }
+
+        uint32_t vkAPIVer = volkGetInstanceVersion();
+        if(vkAPIVer < VK_API_VERSION_1_1) {
+            std::cout << "Minimum supported Vulkan version is 1.1" << std::endl;
+            return nullptr;
+        }
+
+        auto _ToSet = [](auto&& obj) {
+            return std::unordered_set(obj.begin(), obj.end());
+        };
+
+        std::unordered_set<std::string> availableInstanceLayers{ _ToSet(EnumerateInstanceLayers()) };
+        std::unordered_set<std::string> availableInstanceExtensions{ _ToSet(EnumerateInstanceExtensions()) };
+
+       
+
+        VkApplicationInfo appInfo{};
+        appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+        appInfo.pApplicationName = "";
+        appInfo.applicationVersion = 0;
+        appInfo.pEngineName = "alloy";
+        appInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+        //Support highest API version is 1.4
+        appInfo.apiVersion = VK_API_VERSION_1_4;
+
+        VkInstanceCreateInfo createInfo{};
+        createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+        createInfo.pApplicationInfo = &appInfo;
+
+        std::vector<const char*> instanceExtensions{};
+        std::vector<const char*> instanceLayers{};
+
+        auto _AddExtIfPresent = [&](const char* extName){
+            if (availableInstanceExtensions.find(extName) 
+                    != availableInstanceExtensions.end())
+            {
+                instanceExtensions.push_back(extName);
+                return true;
+            }
+            return false;
+        };
+
+        auto _AddLayerIfPresent = [&](const char* layerName) {
+            if (availableInstanceLayers.find(layerName)
+                    != availableInstanceLayers.end())
+            {
+                instanceLayers.push_back(layerName);
+                return true;
+            }
+            return false;
+        };
+
+        Capabilities instCaps {};
+
+        instCaps.hasSurfaceExt = _AddExtIfPresent(VkInstExtNames::VK_KHR_SURFACE);
+        //Surface extensions
+    #ifdef VLD_PLATFORM_WIN32
+        instCaps.hasWin32SurfaceCreateExt = _AddExtIfPresent(VkInstExtNames::VK_KHR_WIN32_SURFACE);
+    #elif defined VLD_PLATFORM_ANDROID
+        instCaps.hasAndroidSurfaceCreateExt = _AddExtIfPresent(VkInstExtNames::VK_KHR_ANDROID_SURFACE);
+    #elif defined VLD_PLATFORM_LINUX
+        instCaps.hasXLibSurfaceCreateExt = _AddExtIfPresent(VkInstExtNames::VK_KHR_XLIB_SURFACE);
+        instCaps.hasWaylandSurfaceCreateExt = _AddExtIfPresent(VkInstExtNames::VK_KHR_WAYLAND_SURFACE);
+    #endif
+
+        instCaps.hasDrvProp2Ext = _AddExtIfPresent(VkInstExtNames::VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES2);
+
+        //Debugging
+        if(opts.debug) {
+            instCaps.hasDebugReportExt 
+                = _AddExtIfPresent(VkInstExtNames::VK_EXT_DEBUG_REPORT);
+            instCaps.hasStandardValidationLayers 
+                = _AddLayerIfPresent(VkCommonStrings::StandardValidationLayerName);
+            instCaps.hasKhronosValidationLayers 
+                = _AddLayerIfPresent(VkCommonStrings::KhronosValidationLayerName);
+        }
+
+        instCaps.hasDebugUtilExt = _AddExtIfPresent(VkInstExtNames::VK_EXT_DEBUG_UTILS);
+
+        createInfo.enabledExtensionCount = instanceExtensions.size();
+        createInfo.ppEnabledExtensionNames = instanceExtensions.data();
+
+        createInfo.enabledLayerCount = instanceLayers.size();
+        createInfo.ppEnabledLayerNames = instanceLayers.data();
+
+        VkInstance instance;
+        VK_CHECK(vkCreateInstance(&createInfo, nullptr, &instance));
+
+        auto pCtx = new VulkanContext(instance);
+        pCtx->_caps = std::move(instCaps);
+        pCtx->_debugCallbackHandle = nullptr;
+        volkLoadInstanceTable(&pCtx->_fnTable, instance);
+
+        if (instCaps.hasDebugReportExt) {
+            //Debug.WriteLine("Enabling Vulkan Debug callbacks.");
+            VkDebugReportCallbackCreateInfoEXT debugCallbackCI{};
+            debugCallbackCI.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT;
+            debugCallbackCI.pNext = nullptr;
+            debugCallbackCI.flags = VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_ERROR_BIT_EXT;
+            debugCallbackCI.pfnCallback = &_DbgCbStatic;
+            debugCallbackCI.pUserData = pCtx;
+
+            VK_CHECK(pCtx->_fnTable.vkCreateDebugReportCallbackEXT(
+                instance, &debugCallbackCI, nullptr, &pCtx->_debugCallbackHandle));       
+        }
+
+        return common::sp {pCtx};
+    }
+
+
+    VkBool32 VulkanContext::_DbgCbStatic(
+        VkDebugReportFlagsEXT                       msgFlags,
+        VkDebugReportObjectTypeEXT                  objectType,
+        uint64_t                                    object,
+        size_t                                      location,
+        int32_t                                     msgCode,
+        const char* pLayerPrefix,
+        const char* pMsg,
+        void* pUserData
+    ) {
+        auto self = (VulkanContext*)pUserData;
+        
+        return self->_DbgCb(msgFlags, objectType, object, location, msgCode, pLayerPrefix, pMsg);
+    }
+        
+
+    VkBool32 VulkanContext::_DbgCb(
+        VkDebugReportFlagsEXT                       msgFlags,
+        VkDebugReportObjectTypeEXT                  objectType,
+        uint64_t                                    object,
+        size_t                                      location,
+        int32_t                                     msgCode,
+        const char* pLayerPrefix,
+        const char* pMsg
+    ) {
+//#define LOG(...) printf(__VA_ARGS__)
+
+        if (msgFlags & VK_DEBUG_REPORT_ERROR_BIT_EXT)
+            std::cout << std::format("ERR " "[{}] [Vk#{}]: {}", std::string(pLayerPrefix), msgCode, std::string(pMsg)) << std::endl;
+        else if (msgFlags & VK_DEBUG_REPORT_WARNING_BIT_EXT)
+            std::cout << std::format("WARN" "[{}] [Vk#{}]: {}", std::string(pLayerPrefix), msgCode, std::string(pMsg)) << std::endl;
+        else if (msgFlags & VK_DEBUG_REPORT_DEBUG_BIT_EXT)
+            std::cout << std::format("DBG " "[{}] [Vk#{}]: {}", std::string(pLayerPrefix), msgCode, std::string(pMsg)) << std::endl;
+        else if (msgFlags & VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT)
+            std::cout << std::format("PERF" "[{}] [Vk#{}]: {}", std::string(pLayerPrefix), msgCode, std::string(pMsg)) << std::endl;
+        else if (msgFlags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT)
+            std::cout << std::format("INFO" "[{}] [Vk#{}]: {}", std::string(pLayerPrefix), msgCode, std::string(pMsg)) << std::endl;
+        return 0;
+//#undef LOG
     }
 
 

--- a/src/backend/vk/VulkanContext.hpp
+++ b/src/backend/vk/VulkanContext.hpp
@@ -16,6 +16,34 @@
 namespace alloy::vk
 {
     class VulkanContext;
+    class VulkanAdapter;
+
+    struct VulkanDevCaps {
+        GraphicsApiVersion apiVersion;
+        VkPhysicalDeviceLimits limits;
+        VkPhysicalDeviceSparseProperties sparseProperties;
+
+        VkPhysicalDeviceVulkan11Properties properties11;
+        VkPhysicalDeviceVulkan12Properties properties12;
+        VkPhysicalDeviceVulkan13Properties properties13;
+        VkPhysicalDeviceVulkan14Properties properties14;
+
+        VkPhysicalDeviceFeatures features;
+        VkPhysicalDeviceVulkan11Features features11;
+        VkPhysicalDeviceVulkan12Features features12;
+        VkPhysicalDeviceVulkan13Features features13;
+        VkPhysicalDeviceVulkan14Features features14;
+
+        bool SupportScalarBlockLayout() const { return features12.scalarBlockLayout; }
+        bool supportMeshShader;
+        bool supportRayTracing;
+        bool supportBindless;
+
+        bool isIntegratedGPU;
+        bool isResizableBARSupported;
+
+        void ReadFromDevice(VulkanContext& ctx, VkPhysicalDevice adp);
+    };
 
     class VulkanAdapter : public IPhysicalAdapter {
 
@@ -29,14 +57,17 @@ namespace alloy::vk
         };
 
     private:
-
         common::sp<VulkanContext> _ctx;
+
         QueueFamilyInfo _qFamily;
 
         VkPhysicalDevice _handle;
 
-        void PopulateAdpLimits();
+        VulkanDevCaps _caps;
+
         void PopulateAdpMemSegs();
+        void PopulateAdpLimits();
+        void PopulateAdpFeatures();
 
     public:
         static common::sp<VulkanAdapter> Make(
@@ -53,7 +84,8 @@ namespace alloy::vk
             const IGraphicsDevice::Options& options) override;
     
         VkPhysicalDevice GetHandle() const {return _handle;}
-        VulkanContext* GetCtx() const {return _ctx.get();}
+        VulkanContext& GetCtx() const {return *_ctx.get();}
+        const VulkanDevCaps& GetCaps() const { return _caps; }
 
         const QueueFamilyInfo& GetQueueFamilyInfo() const {return _qFamily;}
     };
@@ -62,7 +94,7 @@ namespace alloy::vk
     class VulkanContext : public IContext{
 
     public:
-        union Features
+        union Capabilities
         {
             struct {
                 bool hasSurfaceExt : 1;
@@ -77,150 +109,17 @@ namespace alloy::vk
                 bool hasStandardValidationLayers : 1;
                 bool hasKhronosValidationLayers : 1;
 
+                bool hasDebugUtilExt : 1;
+
             };
             std::uint32_t value;
         };
     
     private:
-
+        //Helper class to init/deinit volk library
         class VolkCtx {
-
             static uint32_t _refCnt;
             static std::mutex _m;
-            
-            static Features _features;
-
-            static VkDebugReportCallbackEXT _debugCallbackHandle;
-            static VkBool32 _DbgCb(
-                VkDebugReportFlagsEXT                       msgFlags,
-                VkDebugReportObjectTypeEXT                  objectType,
-                uint64_t                                    object,
-                size_t                                      location,
-                int32_t                                     msgCode,
-                const char* pLayerPrefix,
-                const char* pMsg,
-                void* pUserData)
-            {
-        //#define LOG(...) printf(__VA_ARGS__)
-
-                if (msgFlags & VK_DEBUG_REPORT_ERROR_BIT_EXT)
-                    std::cout << std::format("ERR " "[{}] [Vk#{}]: {}", std::string(pLayerPrefix), msgCode, std::string(pMsg)) << std::endl;
-                else if (msgFlags & VK_DEBUG_REPORT_WARNING_BIT_EXT)
-                    std::cout << std::format("WARN" "[{}] [Vk#{}]: {}", std::string(pLayerPrefix), msgCode, std::string(pMsg)) << std::endl;
-                else if (msgFlags & VK_DEBUG_REPORT_DEBUG_BIT_EXT)
-                    std::cout << std::format("DBG " "[{}] [Vk#{}]: {}", std::string(pLayerPrefix), msgCode, std::string(pMsg)) << std::endl;
-                else if (msgFlags & VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT)
-                    std::cout << std::format("PERF" "[{}] [Vk#{}]: {}", std::string(pLayerPrefix), msgCode, std::string(pMsg)) << std::endl;
-                else if (msgFlags & VK_DEBUG_REPORT_INFORMATION_BIT_EXT)
-                    std::cout << std::format("INFO" "[{}] [Vk#{}]: {}", std::string(pLayerPrefix), msgCode, std::string(pMsg)) << std::endl;
-                return 0;
-        //#undef LOG
-            }
-
-            
-            static void InitContext() {
-                auto _ToSet = [](auto&& obj) {
-                    return std::unordered_set(obj.begin(), obj.end());
-                };
-
-                std::unordered_set<std::string> availableInstanceLayers{ _ToSet(EnumerateInstanceLayers()) };
-                std::unordered_set<std::string> availableInstanceExtensions{ _ToSet(EnumerateInstanceExtensions()) };
-
-                uint32_t vkAPIVer = 0;
-                vkEnumerateInstanceVersion(&vkAPIVer);
-
-                VkApplicationInfo appInfo{};
-                appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
-                appInfo.pApplicationName = "";
-                appInfo.applicationVersion = 0;
-                appInfo.pEngineName = "alloy";
-                appInfo.engineVersion = VK_MAKE_VERSION(1, 0, 0);
-                appInfo.apiVersion = VK_API_VERSION_1_0;
-
-                VkInstanceCreateInfo createInfo{};
-                createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
-                createInfo.pApplicationInfo = &appInfo;
-
-                std::vector<const char*> instanceExtensions{};
-                std::vector<const char*> instanceLayers{};
-
-                auto _AddExtIfPresent = [&](const char* extName){
-                    if (availableInstanceExtensions.find(extName) 
-                            != availableInstanceExtensions.end())
-                    {
-                        instanceExtensions.push_back(extName);
-                        return true;
-                    }
-                    return false;
-                };
-
-                auto _AddLayerIfPresent = [&](const char* layerName) {
-                    if (availableInstanceLayers.find(layerName)
-                            != availableInstanceLayers.end())
-                    {
-                        instanceLayers.push_back(layerName);
-                        return true;
-                    }
-                    return false;
-                };
-
-                _features.hasSurfaceExt = _AddExtIfPresent(VkInstExtNames::VK_KHR_SURFACE);
-                //Surface extensions
-            #ifdef VLD_PLATFORM_WIN32
-                _features.hasWin32SurfaceCreateExt = _AddExtIfPresent(VkInstExtNames::VK_KHR_WIN32_SURFACE);
-            #elif defined VLD_PLATFORM_ANDROID
-                _features.hasAndroidSurfaceCreateExt = _AddExtIfPresent(VkInstExtNames::VK_KHR_ANDROID_SURFACE);
-            #elif defined VLD_PLATFORM_LINUX
-                _features.hasXLibSurfaceCreateExt = _AddExtIfPresent(VkInstExtNames::VK_KHR_XLIB_SURFACE);
-                _features.hasWaylandSurfaceCreateExt = _AddExtIfPresent(VkInstExtNames::VK_KHR_WAYLAND_SURFACE);
-            #endif
-
-                _features.hasDrvProp2Ext = _AddExtIfPresent(VkInstExtNames::VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES2);
-
-                //Debugging
-            #ifdef VLD_DEBUG
-                _features.hasDebugReportExt 
-                    = _AddExtIfPresent(VkInstExtNames::VK_EXT_DEBUG_REPORT);
-                _features.hasStandardValidationLayers 
-                    = _AddLayerIfPresent(VkCommonStrings::StandardValidationLayerName);
-                _features.hasStandardValidationLayers 
-                    = _AddLayerIfPresent(VkCommonStrings::KhronosValidationLayerName);
-            #endif  
-
-                createInfo.enabledExtensionCount = instanceExtensions.size();
-                createInfo.ppEnabledExtensionNames = instanceExtensions.data();
-
-                createInfo.enabledLayerCount = instanceLayers.size();
-                createInfo.ppEnabledLayerNames = instanceLayers.data();
-
-                VkInstance instance;
-                VK_CHECK(vkCreateInstance(&createInfo, nullptr, &instance));
-                volkLoadInstanceOnly(instance);
-
-                
-                if (_features.hasDebugReportExt) {
-                    //Debug.WriteLine("Enabling Vulkan Debug callbacks.");
-                    VkDebugReportCallbackCreateInfoEXT debugCallbackCI{};
-                    debugCallbackCI.sType = VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT;
-                    debugCallbackCI.pNext = nullptr;
-                    debugCallbackCI.flags = VK_DEBUG_REPORT_WARNING_BIT_EXT | VK_DEBUG_REPORT_ERROR_BIT_EXT;
-                    debugCallbackCI.pfnCallback = &_DbgCb;
-
-                    VK_CHECK(vkCreateDebugReportCallbackEXT(
-                        instance, &debugCallbackCI, nullptr, &_debugCallbackHandle));       
-                }
-            }
-
-            
-            static void DestroyContext() {
-                auto instance = volkGetLoadedInstance();
-                if (_debugCallbackHandle != VK_NULL_HANDLE) {
-                    vkDestroyDebugReportCallbackEXT(instance, _debugCallbackHandle, nullptr);
-                }
-
-                vkDestroyInstance(instance, nullptr);
-            }
-
         public:
             static bool Ref() {
                 std::scoped_lock lock {_m};
@@ -228,7 +127,6 @@ namespace alloy::vk
                     auto res = volkInitialize();
                     if(res == VK_SUCCESS) {
                         _refCnt++;
-                        InitContext();
                         return true;
                     }
                     else { return false; }
@@ -242,48 +140,65 @@ namespace alloy::vk
                 std::scoped_lock lock {_m};
                 if(_refCnt == 0) return;
                 if(_refCnt == 1) {
-                    DestroyContext();
                     volkFinalize();
                 }
                 _refCnt--;
             }
-
-            static const Features& GetFeatures() { return _features; }
         };
 
     private:
 
         VkInstance _instance;
-        alloy::GraphicsApiVersion _ver;
 
-        VulkanContext():
-            _instance(VK_NULL_HANDLE)
-        {
-            _instance = volkGetLoadedInstance();
+        Capabilities _caps;
+        
+        VolkInstanceTable _fnTable;
 
-            auto version = volkGetInstanceVersion();
-            _ver.major = VK_VERSION_MAJOR(version);
-            _ver.minor = VK_VERSION_MINOR(version);
-            _ver.patch = VK_VERSION_PATCH(version);
-        }
+        VulkanContext(VkInstance instance):
+            _instance(instance)
+        { }
+
+        //#TODO: Figure out proper way to do handle creation when
+        //multiple context exists
+        VkDebugReportCallbackEXT _debugCallbackHandle;
+        
+        static VkBool32 _DbgCbStatic(
+            VkDebugReportFlagsEXT                       msgFlags,
+            VkDebugReportObjectTypeEXT                  objectType,
+            uint64_t                                    object,
+            size_t                                      location,
+            int32_t                                     msgCode,
+            const char* pLayerPrefix,
+            const char* pMsg,
+            void* pUserData);
+
+        VkBool32 _DbgCb(
+            VkDebugReportFlagsEXT                       msgFlags,
+            VkDebugReportObjectTypeEXT                  objectType,
+            uint64_t                                    object,
+            size_t                                      location,
+            int32_t                                     msgCode,
+            const char* pLayerPrefix,
+            const char* pMsg);
 
     public:
 
         virtual ~VulkanContext() override {
+
+            if (_debugCallbackHandle != VK_NULL_HANDLE) {
+                _fnTable.vkDestroyDebugReportCallbackEXT(_instance, _debugCallbackHandle, nullptr);
+            }
+            _fnTable.vkDestroyInstance(_instance, nullptr);
             DEBUGCODE(_instance = nullptr);
-            VolkCtx::Release();            
+            VolkCtx::Release();
         }
 
-        static common::sp<VulkanContext> Make(const IContext::Options& opts) {
-            //assert(false);//figure out a way to set debug extensions
-            if(!VolkCtx::Ref()) return nullptr;
-            return common::sp{ new VulkanContext() };
-        }
+        static common::sp<VulkanContext> Make(const IContext::Options& opts);
 
-        const VkInstance& GetHandle() const { return _instance; }
+        VkInstance GetHandle() const { return _instance; }
+        const VolkInstanceTable& GetFnTable() const { return _fnTable; }
 
-        const Features& GetFeatures() const { return VolkCtx::GetFeatures(); }
-        const alloy::GraphicsApiVersion& GetApiVer() const { return _ver; }
+        const Capabilities& GetCaps() const { return _caps; }
 
         virtual common::sp<IGraphicsDevice> CreateDefaultDevice(
             const IGraphicsDevice::Options& options) override;

--- a/src/backend/vk/VulkanDevice.cpp
+++ b/src/backend/vk/VulkanDevice.cpp
@@ -72,7 +72,8 @@ bool Contains(T&& container, U&& element) {
 		const common::sp<VulkanAdapter>& adp,
 		const IGraphicsDevice::Options& options
 	){
-        auto ctx = adp->GetCtx();
+        auto& ctx = adp->GetCtx();
+        auto& devCaps = adp->GetCaps();
 
         //Make the surface if possible
         //VK::priv::SurfaceContainer _surf = {VK_NULL_HANDLE, false};
@@ -141,18 +142,33 @@ bool Contains(T&& container, U&& element) {
         createInfo.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
 
         VkPhysicalDeviceFeatures deviceFeatures{};
-        vkGetPhysicalDeviceFeatures(adp->GetHandle(), &deviceFeatures);
+        ctx.GetFnTable().vkGetPhysicalDeviceFeatures(adp->GetHandle(), &deviceFeatures);
 
-        VkPhysicalDeviceSynchronization2FeaturesKHR syncFeatures{
-            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES_KHR,
-            .synchronization2 = 1u
-        };
+        
+        VkPhysicalDeviceVulkan11Features features11 { };
+        features11.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES;
+        features11.shaderDrawParameters = true; //Not sure, required by dxil-spirv
+        createInfo.pNext = &features11;
 
         VkPhysicalDeviceVulkan12Features features12 { };
-        features12.pNext = &syncFeatures;
         features12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES;
         features12.timelineSemaphore = true;
-        createInfo.pNext = &features12;
+
+        if(devCaps.supportBindless) {
+            features12.descriptorIndexing = true;
+            features12.descriptorBindingPartiallyBound = true;
+        }
+
+        if(devCaps.SupportScalarBlockLayout()) {
+            features12.scalarBlockLayout = true;
+        }
+        
+        features11.pNext = &features12;
+
+        //VkPhysicalDeviceScalarBlockLayoutFeatures scalarBlockLayoutFeatures { };
+        //scalarBlockLayoutFeatures.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES;
+        //scalarBlockLayoutFeatures.scalarBlockLayout = VK_TRUE;
+        //features12.pNext = &scalarBlockLayoutFeatures;
 
         VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamicRenderingFeature { };
         dynamicRenderingFeature.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES_KHR,
@@ -163,6 +179,11 @@ bool Contains(T&& container, U&& element) {
         sync2Features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES;
         sync2Features.synchronization2 = VK_TRUE;
         dynamicRenderingFeature.pNext = &sync2Features;
+
+        VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT dynRndrUnusedAttachments { };
+        dynRndrUnusedAttachments.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT;
+        dynRndrUnusedAttachments.dynamicRenderingUnusedAttachments = VK_TRUE;
+        sync2Features.pNext = &dynRndrUnusedAttachments;
 
         //First add pointers to the queue creation info and device features structs:
 
@@ -175,11 +196,11 @@ bool Contains(T&& container, U&& element) {
         {
 
             std::uint32_t propCount = 0;
-            VK_CHECK(vkEnumerateDeviceExtensionProperties(adp->GetHandle(), nullptr, &propCount, nullptr));
+            VK_CHECK(ctx.GetFnTable().vkEnumerateDeviceExtensionProperties(adp->GetHandle(), nullptr, &propCount, nullptr));
 
             if (propCount != 0) {
                 std::vector<VkExtensionProperties> props(propCount);
-                VK_CHECK(vkEnumerateDeviceExtensionProperties(
+                VK_CHECK(ctx.GetFnTable().vkEnumerateDeviceExtensionProperties(
                     adp->GetHandle(), nullptr, &propCount, props.data()));
 
                 
@@ -191,7 +212,20 @@ bool Contains(T&& container, U&& element) {
             }
         }
 
-        std::vector<const char*> devExtensions{};
+
+        std::vector<const char*> devExtensions{
+            //Prefill required extensions
+            VkDevExtNames::VK_KHR_SYNCHRONIZATION2,
+            VkDevExtNames::VK_KHR_TIMELINE_SEMAPHORE,
+            VkDevExtNames::VK_KHR_DYNAMIC_RENDERING,
+            VK_EXT_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_EXTENSION_NAME,
+            VkDevExtNames::VK_KHR_DEPTH_STENCIL_RESOLVE,
+            VkDevExtNames::VK_KHR_CREATE_RENDERPASS2,
+            VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME,
+            VkDevExtNames::VK_KHR_MAINTENANCE1,
+        };
+
+
         auto _AddExtIfPresent = [&](const char* extName) {
             if (Contains(availableDevExts, extName))
             {
@@ -201,24 +235,24 @@ bool Contains(T&& container, U&& element) {
             return false;
         };
 
-        if(!_AddExtIfPresent(VkDevExtNames::VK_KHR_TIMELINE_SEMAPHORE)) {
-            throw std::exception("VkDevice creation failed. Timeline semaphore not supported");
-        }
+        //if(!_AddExtIfPresent(VkDevExtNames::VK_KHR_TIMELINE_SEMAPHORE)) {
+        //    throw std::exception("VkDevice creation failed. Timeline semaphore not supported");
+        //}
+        //
+        //if(!_AddExtIfPresent(VkDevExtNames::VK_KHR_DYNAMIC_RENDERING) ||
+        //   !_AddExtIfPresent(VkDevExtNames::VK_KHR_DEPTH_STENCIL_RESOLVE) ||
+        //   !_AddExtIfPresent(VkDevExtNames::VK_KHR_CREATE_RENDERPASS2)
+        //) {
+        //    throw std::exception("VkDevice creation failed. dynamic rendering not supported");
+        //}
+        //
+        //if(!_AddExtIfPresent(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
+        //    throw std::exception("VkDevice creation failed. synchronization2 not supported");
+        //}
 
-        if(!_AddExtIfPresent(VkDevExtNames::VK_KHR_DYNAMIC_RENDERING) ||
-           !_AddExtIfPresent(VkDevExtNames::VK_KHR_DEPTH_STENCIL_RESOLVE) ||
-           !_AddExtIfPresent(VkDevExtNames::VK_KHR_CREATE_RENDERPASS2)
-        ) {
-            throw std::exception("VkDevice creation failed. dynamic rendering not supported");
-        }
 
-        if(!_AddExtIfPresent(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME)) {
-            throw std::exception("VkDevice creation failed. synchronization2 not supported");
-        }
-
-
-        if (options.debug)
-            dev->_features.supportsDebug = _AddExtIfPresent(VkDevExtNames::VK_EXT_DEBUG_MARKER);
+        //if (options.debug)
+        //    dev->_features.supportsDebug = _AddExtIfPresent(VkDevExtNames::VK_EXT_DEBUG_UTILS);
 
         dev->_features.supportsPresent = _AddExtIfPresent(VkDevExtNames::VK_KHR_SWAPCHAIN);
         if (options.preferStandardClipSpaceYDirection) {
@@ -227,7 +261,7 @@ bool Contains(T&& container, U&& element) {
         dev->_features.supportsGetMemReq2 = _AddExtIfPresent(VkDevExtNames::VK_KHR_GET_MEMORY_REQ2);
         dev->_features.supportsDedicatedAlloc = _AddExtIfPresent(VkDevExtNames::VK_KHR_DEDICATED_ALLOCATION);
 
-        if (ctx->GetFeatures().hasDrvProp2Ext) {
+        if (ctx.GetCaps().hasDrvProp2Ext) {
             dev->_features.supportsDrvPropQuery = _AddExtIfPresent(VkDevExtNames::VK_KHR_DRIVER_PROPS);
         }
 
@@ -237,7 +271,7 @@ bool Contains(T&& container, U&& element) {
         createInfo.ppEnabledExtensionNames = devExtensions.data();
 
         createInfo.pEnabledFeatures = &deviceFeatures;
-        VK_CHECK(vkCreateDevice(adp->GetHandle(), &createInfo, nullptr, &dev->_dev));
+        VK_CHECK(ctx.GetFnTable().vkCreateDevice(adp->GetHandle(), &createInfo, nullptr, &dev->_dev));
 
         volkLoadDeviceTable(&dev->_fnTable, dev->_dev);
 
@@ -270,13 +304,14 @@ bool Contains(T&& container, U&& element) {
                                                     qInfo.computeQueueFamily.value(),
                                                     rawComputeQ);
         }
-
+        auto apiVer = adp->GetAdapterInfo().apiVersion;
+        
         //Init allocator
         VmaAllocatorCreateInfo allocatorInfo = {};
-        allocatorInfo.vulkanApiVersion = VK_API_VERSION_1_0;
+        allocatorInfo.vulkanApiVersion = VK_MAKE_API_VERSION(0, apiVer.major, apiVer.minor, apiVer.patch);
         allocatorInfo.physicalDevice = adp->GetHandle();
         allocatorInfo.device = dev->_dev;
-        allocatorInfo.instance = adp->GetCtx()->GetHandle();
+        allocatorInfo.instance = adp->GetCtx().GetHandle();
 
         VmaVulkanFunctions fn{};
         fn.vkGetInstanceProcAddr = vkGetInstanceProcAddr;
@@ -334,7 +369,7 @@ bool Contains(T&& container, U&& element) {
 
 
         VkPhysicalDeviceProperties deviceProps{};
-        vkGetPhysicalDeviceProperties(adp->GetHandle(), &deviceProps);
+        ctx.GetFnTable().vkGetPhysicalDeviceProperties(adp->GetHandle(), &deviceProps);
 
         dev->_commonFeat.computeShader = dev->_features.hasComputeCap;
         dev->_commonFeat.geometryShader = deviceFeatures.geometryShader;
@@ -873,7 +908,7 @@ bool Contains(T&& container, U&& element) {
             if(it == _currentState.textures.end()) {
                 currLayout = cpuTimeline.textures[texture];
             } else {
-                auto& state = it->second;
+                currLayout = it->second;
             }
             //Acquire resource on this timeline
             texture->NotifyUsageOn(this);

--- a/src/backend/vk/VulkanDevice.hpp
+++ b/src/backend/vk/VulkanDevice.hpp
@@ -18,14 +18,14 @@
 #include <mutex>
 
 #include "VkDescriptorPoolMgr.hpp"
+#include "VulkanContext.hpp"
 #include "VulkanResourceFactory.hpp"
 
 #define VK_DEV_CALL(dev, expr) (dev->GetFnTable(). expr )
+#define VK_INST_CALL(dev, expr) (dev->GetContext().GetFnTable(). expr )
 
 namespace alloy::vk
 {
-    //class _VkCtx;
-    class VulkanAdapter;
     class VulkanBuffer;
     class VulkanTexture;
     class VulkanDevice;
@@ -277,6 +277,8 @@ namespace alloy::vk
         virtual const IGraphicsDevice::Features& GetFeatures() const override { return _commonFeat; }
         virtual IPhysicalAdapter& GetAdapter() const override;
 
+        VulkanContext& GetContext() const { return _adp->GetCtx(); }
+
         virtual ResourceFactory& GetResourceFactory() override { return *this; };
 
         //const PhyDevInfo& GetPhyDevInfo() const {return _phyDev;}
@@ -365,14 +367,14 @@ namespace alloy::vk
 
         virtual void SetDebugName(const std::string & name) override {
             // Check for a valid function pointer
-	        if (_dev->GetFeatures().commandListDebugMarkers)
+	        if (_dev->GetContext().GetCaps().hasDebugUtilExt)
 	        {
-	        	VkDebugMarkerObjectNameInfoEXT nameInfo = {};
-	        	nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
-	        	nameInfo.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT;
-	        	nameInfo.object = (uint64_t)_buffer;
+	        	VkDebugUtilsObjectNameInfoEXT nameInfo = {};
+	        	nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+	        	nameInfo.objectType = VK_OBJECT_TYPE_BUFFER;
+	        	nameInfo.objectHandle = (uint64_t)_buffer;
 	        	nameInfo.pObjectName = name.c_str();
-                _dev->GetFnTable().vkDebugMarkerSetObjectNameEXT(_dev->LogicalDev(), &nameInfo);
+                VK_INST_CALL(_dev, vkSetDebugUtilsObjectNameEXT(_dev->LogicalDev(), &nameInfo));
 	        }
 
             _debugName = name;

--- a/src/backend/vk/VulkanPipeline.cpp
+++ b/src/backend/vk/VulkanPipeline.cpp
@@ -802,7 +802,7 @@ public:
             remapper.SetStage(alloy::IShader::Stage::Vertex);
 
             alloy::vk::SPIRVBlob spvBlob;
-            auto cvtRes = alloy::vk::DXIL2SPV(dxil, compiler_args, remapper, spvBlob);
+            auto cvtRes = alloy::vk::DXIL2SPV(*dev, dxil, compiler_args, remapper, spvBlob);
             VK_ASSERT(cvtRes == alloy::vk::ShaderConverterResult::Success);
 
             VkShaderModuleCreateInfo shaderModuleCI {};
@@ -835,7 +835,7 @@ public:
             remapper.SetStage(alloy::IShader::Stage::Fragment);
 
             alloy::vk::SPIRVBlob spvBlob;
-            auto cvtRes = alloy::vk::DXIL2SPV(dxil, compiler_args, remapper, spvBlob);
+            auto cvtRes = alloy::vk::DXIL2SPV(*dev, dxil, compiler_args, remapper, spvBlob);
             VK_ASSERT(cvtRes == alloy::vk::ShaderConverterResult::Success);
 
             VkShaderModuleCreateInfo shaderModuleCI {};
@@ -1045,7 +1045,7 @@ public:
             remapper.SetStage(alloy::IShader::Stage::Compute);
 
             alloy::vk::SPIRVBlob spvBlob;
-            auto cvtRes = alloy::vk::DXIL2SPV(dxil, compiler_args, remapper, spvBlob);
+            auto cvtRes = alloy::vk::DXIL2SPV(*dev, dxil, compiler_args, remapper, spvBlob);
             VK_ASSERT(cvtRes == alloy::vk::ShaderConverterResult::Success);
 
             VkShaderModuleCreateInfo shaderModuleCI {};

--- a/src/backend/vk/VulkanShader.cpp
+++ b/src/backend/vk/VulkanShader.cpp
@@ -214,10 +214,13 @@ namespace alloy::vk
         return true;
     }
     
-    ShaderConverterResult DXIL2SPV(const std::span<uint8_t>& dxil,
+    ShaderConverterResult DXIL2SPV(VulkanDevice& device,
+                                   const std::span<uint8_t>& dxil,
                                    const ConverterCompilerArgs& compiler_args,
                                    SPVRemapper& remapper,
                                    SPIRVBlob& spirv) {
+        
+        const auto& devLimit = device.GetAdapter().GetAdapterInfo().limits;
         
         //dxil_spv_converter converter = nullptr;
         //dxil_spv_parsed_blob blob = nullptr;
@@ -268,6 +271,19 @@ namespace alloy::vk
             if (dxil_spv_converter_add_option(converter.converter, &compute_shader_derivatives.base) != DXIL_SPV_SUCCESS)
             {
                 //ERR("dxil-spirv does not support COMPUTE_SHADER_DERIVATIVES.\n");
+                ret = VKD3D_ERROR_NOT_IMPLEMENTED;
+                assert(false);
+                break;
+            }
+
+            dxil_spv_option_ssbo_alignment ssbo_alignment {
+                .base = { DXIL_SPV_OPTION_SSBO_ALIGNMENT },
+                .alignment = (uint32_t)devLimit.minStructuredBufferStride
+            };
+
+            if (dxil_spv_converter_add_option(converter.converter, &ssbo_alignment.base) != DXIL_SPV_SUCCESS)
+            {
+                //ERR("dxil-spirv does not support ssbo_alignment.\n");
                 ret = VKD3D_ERROR_NOT_IMPLEMENTED;
                 assert(false);
                 break;

--- a/src/backend/vk/VulkanShader.hpp
+++ b/src/backend/vk/VulkanShader.hpp
@@ -12,6 +12,9 @@
 #include <functional>
 
 namespace alloy::vk {
+
+    class VulkanDevice;
+
     enum ShaderConverterResult {
         Success,
         VKD3D_ERROR_INVALID_SHADER,
@@ -145,7 +148,8 @@ namespace alloy::vk {
 
     };
 
-    ShaderConverterResult DXIL2SPV(const std::span<uint8_t>& dxil,
+    ShaderConverterResult DXIL2SPV(VulkanDevice& device,
+                                   const std::span<uint8_t>& dxil,
                                    const ConverterCompilerArgs& compiler_args,
                                    SPVRemapper& remapper,
                                    SPIRVBlob& spirv);

--- a/src/backend/vk/VulkanSwapChain.cpp
+++ b/src/backend/vk/VulkanSwapChain.cpp
@@ -19,11 +19,11 @@ namespace alloy::vk
     {
         auto& vulkanAdp = static_cast<VulkanAdapter&>(dev->GetAdapter());
         VkBool32 supported;
-        VK_CHECK(vkGetPhysicalDeviceSurfaceSupportKHR(
+        VK_CHECK(VK_INST_CALL(dev, vkGetPhysicalDeviceSurfaceSupportKHR(
             vulkanAdp.GetHandle(),
             queueFamilyIndex,
             surface,
-            &supported));
+            &supported)));
         
         return supported;
     }
@@ -422,10 +422,10 @@ namespace alloy::vk
         }
         // Obtain the surface capabilities first -- this will indicate whether the surface has been lost.
         VkSurfaceCapabilitiesKHR surfaceCapabilities;
-        VkResult result = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+        VkResult result = VK_INST_CALL(_dev, vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
             vulkanAdp.GetHandle(), 
             surface, 
-            &surfaceCapabilities);
+            &surfaceCapabilities));
 
         if (result == VkResult::VK_ERROR_SURFACE_LOST_KHR)
         {
@@ -448,9 +448,9 @@ namespace alloy::vk
 
         _currentImageIndex = 0;
         std::uint32_t surfaceFormatCount = 0;
-        VK_CHECK(vkGetPhysicalDeviceSurfaceFormatsKHR(vulkanAdp.GetHandle(), surface, &surfaceFormatCount, nullptr));
+        VK_CHECK(VK_INST_CALL(_dev, vkGetPhysicalDeviceSurfaceFormatsKHR(vulkanAdp.GetHandle(), surface, &surfaceFormatCount, nullptr)));
         std::vector<VkSurfaceFormatKHR> formats (surfaceFormatCount);
-        VK_CHECK(vkGetPhysicalDeviceSurfaceFormatsKHR(vulkanAdp.GetHandle(), surface, &surfaceFormatCount, formats.data()));
+        VK_CHECK(VK_INST_CALL(_dev, vkGetPhysicalDeviceSurfaceFormatsKHR(vulkanAdp.GetHandle(), surface, &surfaceFormatCount, formats.data())));
 
         VkFormat desiredFormat = description.colorSrgb
             ? VkFormat::VK_FORMAT_B8G8R8A8_SRGB
@@ -484,9 +484,9 @@ namespace alloy::vk
         }
 
         std::uint32_t presentModeCount = 0;
-        VK_CHECK(vkGetPhysicalDeviceSurfacePresentModesKHR(vulkanAdp.GetHandle(), surface, &presentModeCount, nullptr));
+        VK_CHECK(VK_INST_CALL(_dev, vkGetPhysicalDeviceSurfacePresentModesKHR(vulkanAdp.GetHandle(), surface, &presentModeCount, nullptr)));
         std::vector<VkPresentModeKHR> presentModes(presentModeCount);
-        VK_CHECK(vkGetPhysicalDeviceSurfacePresentModesKHR(vulkanAdp.GetHandle(), surface, &presentModeCount, presentModes.data()));
+        VK_CHECK(VK_INST_CALL(_dev, vkGetPhysicalDeviceSurfacePresentModesKHR(vulkanAdp.GetHandle(), surface, &presentModeCount, presentModes.data())));
         
         VkPresentModeKHR presentMode = VkPresentModeKHR::VK_PRESENT_MODE_FIFO_KHR;
 
@@ -582,14 +582,14 @@ namespace alloy::vk
         
         auto& vulkanAdp = static_cast<VulkanAdapter&>(_dev->GetAdapter());
 
-        auto inst = vulkanAdp.GetCtx()->GetHandle();
+        auto inst = vulkanAdp.GetCtx().GetHandle();
 
         VK_DEV_CALL(_dev, vkDestroyFence(_dev->LogicalDev(), _imageAvailableFence, nullptr));
         //_framebuffer.Dispose();
         VK_DEV_CALL(_dev, vkDestroySwapchainKHR(_dev->LogicalDev(), _deviceSwapchain, nullptr));
 
         if(_surf.isOwnSurface){
-            vkDestroySurfaceKHR(inst, _surf.surface, nullptr);
+            VK_INST_CALL(_dev, vkDestroySurfaceKHR(inst, _surf.surface, nullptr));
         }
     }
 
@@ -606,8 +606,8 @@ namespace alloy::vk
 
         if (_swapchainSource != nullptr) {
             auto& vulkanAdp = static_cast<VulkanAdapter&>(dev->GetAdapter());
-            auto inst = vulkanAdp.GetCtx()->GetHandle();
-            _surf = VK::priv::CreateSurface(inst, _swapchainSource);
+            auto inst = vulkanAdp.GetCtx().GetHandle();
+            _surf = VK::priv::CreateSurface(dev->GetContext(), _swapchainSource);
         }
 
         //auto _surface = dev->Surface();

--- a/src/backend/vk/VulkanTexture.cpp
+++ b/src/backend/vk/VulkanTexture.cpp
@@ -619,15 +619,18 @@ namespace alloy::vk {
 
     void VulkanTexture::SetDebugName(const std::string& name) {
         // Check for a valid function pointer
-        if (_dev->GetFeatures().commandListDebugMarkers)
+
+        if (_dev->GetContext().GetCaps().hasDebugUtilExt)
         {
-            VkDebugMarkerObjectNameInfoEXT nameInfo = {};
-            nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT;
-            nameInfo.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT;
-            nameInfo.object = (uint64_t)_img;
+            VkDebugUtilsObjectNameInfoEXT nameInfo = {};
+            nameInfo.sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT;
+            nameInfo.objectType = VK_OBJECT_TYPE_IMAGE;
+            nameInfo.objectHandle = (uint64_t)_img;
             nameInfo.pObjectName = name.c_str();
-            _dev->GetFnTable().vkDebugMarkerSetObjectNameEXT(_dev->LogicalDev(), &nameInfo);
+            VK_INST_CALL(_dev, vkSetDebugUtilsObjectNameEXT(_dev->LogicalDev(), &nameInfo));
         }
+
+        _debugName = name;
     }
 
     void VulkanTexture::NotifyUsageOn(IVkTimeline* timeline) {

--- a/src/backend/vk/VulkanTexture.hpp
+++ b/src/backend/vk/VulkanTexture.hpp
@@ -25,6 +25,8 @@ namespace alloy::vk
         //Layout tracking
         std::unordered_set<IVkTimeline*> timelines;
 
+        std::string _debugName;
+
 
         VulkanTexture(
             const common::sp<VulkanDevice>& dev,


### PR DESCRIPTION
Bugfixes and mantenance changes

### All
- Add mesh shader, ray tracing & resizable BAR query

### DX12
- Load DX12 dlls on demand during context creation instead of using implib to load at app start
- Remove dependencies of WinPixEventRuntime and use built-in encoding functions for command list debug functions
- Move D3D12DevCaps into DXCAdapter creation as is more approprate

### Vulkan
- Update dependencies to support Vulkan 1.4
- Centralize physical device caps query into VulkanDevCaps similar to DX12 one
- Add block_scalar_layout and shader_draw_parameter query and pass that to dxil-spirv to create correct SPIR-V shader blobs
- Bugfix: auto resource state tracking not working for texture layouts
- Bugfix: incorrect buffer size and offset during resource set creation